### PR TITLE
Fix buffer flushing. Prevent from forgetting not sent messages.

### DIFF
--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -280,23 +280,27 @@
              flush-buffer!
              (fn [type]
                (when-let [pulled (encore/swap-in! send-buffers_ [type]
-                                   (fn [m] (encore/swapped (dissoc m uid)
-                                                           (get    m uid))))]
+                                   (fn [m]
+                                     ;; Don't actually flush unless the event buffered with _this_
+                                     ;; send call is still buffered (awaiting flush). This means
+                                     ;; that we'll have many (go block) buffer flush calls that'll
+                                     ;; noop. They're cheap, and this approach is preferable to
+                                     ;; alternatives like flush workers.
+                                     (let [[_ ev-uuids] (get m uid)]
+                                       (if (contains? ev-uuids ev-uuid)
+                                         (encore/swapped (dissoc m uid)
+                                                         (get    m uid))
+                                         (encore/swapped m nil)))))]
                  (let [[buffered-evs ev-uuids] pulled]
                    (assert (vector? buffered-evs))
                    (assert (set?    ev-uuids))
-                   ;; Don't actually flush unless the event buffered with _this_
-                   ;; send call is still buffered (awaiting flush). This means
-                   ;; that we'll have many (go block) buffer flush calls that'll
-                   ;; noop. They're cheap, and this approach is preferable to
-                   ;; alternatives like flush workers.
-                   (when (contains? ev-uuids ev-uuid)
-                     (let [buffered-evs-edn (pr-str buffered-evs)]
-                       (case type
-                         :ws   (send-buffered-evs>ws-clients!   conns_
-                                 uid buffered-evs-edn)
-                         :ajax (send-buffered-evs>ajax-clients! conns_
-                                 uid buffered-evs-edn)))))))]
+
+                   (let [buffered-evs-edn (pr-str buffered-evs)]
+                     (case type
+                       :ws   (send-buffered-evs>ws-clients!   conns_
+                               uid buffered-evs-edn)
+                       :ajax (send-buffered-evs>ajax-clients! conns_
+                               uid buffered-evs-edn))))))]
 
          (if (= ev [:chsk/close])
            (do


### PR DESCRIPTION
Hi,
I found a bug in flush-buffer!.
In 0.13.0 when not (contains? ev-uuids ev-uuid) messages pulled from send-buffers_ will be dropped. 
