### PR TITLE
Remove non-existent and unused utils import.

### DIFF
--- a/test/taoensso/sente/tests/main.clj
+++ b/test/taoensso/sente/tests/main.clj
@@ -1,7 +1,6 @@
 (ns taoensso.sente.tests.main
   (:require [expectations   :as test :refer :all]
-            [taoensso.sente :as sente  :refer ()]
-            [taoensso.sente.utils :as utils]))
+            [taoensso.sente :as sente  :refer ()]))
 
 (comment (test/run-tests '[taoensso.sente.tests.main]))
 


### PR DESCRIPTION
`lein test` fails because `taoensso.sente.utils` does not exist. This change makes the tests pass for me.
