### PR TITLE
Experimental support for transit

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.taoensso/sente "0.15.1"
+(defproject com.taoensso/sente "0.15.1-SNAPSHOT"
   :author "Peter Taoussanis <https://www.taoensso.com>"
   :description "Clojure channel sockets library"
   :url "https://github.com/ptaoussanis/sente"
@@ -17,7 +17,9 @@
    [org.clojure/tools.reader  "0.8.5"]
    [com.taoensso/encore       "1.7.0"]
    [com.taoensso/timbre       "3.2.1"]
-   [http-kit                  "2.1.18"]]
+   [http-kit                  "2.1.18"]
+   [com.cognitect/transit-clj "0.8.247"]
+   [com.cognitect/transit-cljs "0.8.182"]]
 
   :plugins
   [[com.keminglabs/cljx "0.4.0"]


### PR DESCRIPTION
Added transit as an option (:data-format) to make-channel-socket! (server and client side).

Did some benchmarks to compare edn and transit.

Performed locally on chrome v37 (linux) on an i7-2620m cpu.

Payload: vector of simple maps (size in kb - serialized). Times in ms

| format | payload | # runs | time | high | low | avg |
| --- | --- | --- | --- | --- | --- | --- |
| transit | 1024 | 100 | 8409 | 74 | 43 | 57.25 |
| transit | 512 | 100 | 4973 | 62 | 26 | 34.13 |
| transit | 256 | 100 | 3142 | 61 | 16 | 22.93 |
| transit | 128 | 100 | 2379 | 27 | 7 | 15.9 |
| transit | 64 | 100 | 1745 | 24 | 4 | 11.27 |
| transit | 32 | 100 | 1596 | 28 | 3 | 10.05 |
| transit | 8 | 100 | 1671 | 63 | 3 | 12.71 |
| edn | 1024 | 100 | 66500 | 816 | 534 | 641.69 |
| edn | 512 | 100 | 34542 | 465 | 267 | 332.72 |
| edn | 256 | 100 | 15065 | 246 | 89 | 143.04 |
| edn | 128 | 100 | 8586 | 150 | 63 | 81.84 |
| edn | 64 | 100 | 4642 | 79 | 35 | 44.09 |
| edn | 32 | 100 | 3182 | 57 | 20 | 30.13 |
| edn | 8 | 100 | 2017 | 48 | 6 | 16.53 |
