### PR TITLE
exclude cljx files from jar

### DIFF
--- a/example-project/src/example/my_app.cljx
+++ b/example-project/src/example/my_app.cljx
@@ -74,7 +74,7 @@
      :stop-fn (fn [] (http-kit-stop-fn :timeout 100))}))
 
 ;;; Immutant
-;; #+clj (def web-server--adapter taoensso.sente.server-adapters.immutant/immutant-adapter)
+;; #+clj (def web-server-adapter taoensso.sente.server-adapters.immutant/immutant-adapter)
 ;; #+clj
 ;; (defn start-web-server!* [ring-handler port]
 ;;   (println "Starting Immutant...")

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
             :distribution :repo
             :comments "Same as Clojure"}
   :min-lein-version "2.3.3"
+  :jar-exclusions [#"\.cljx|\.DS_Store"]
   :global-vars {*warn-on-reflection* true
                 *assert* true}
 


### PR DESCRIPTION
Prevents cljx files from making it into the published jar. This may fix an issue I'm having with execution at the emacs repl. These shouldn't get passed along, in any case.