### PR TITLE
Added code snippet with `wrap-keyword-params` and `wrap-params`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ For Sente, we're going to add 2 new URLs and setup their handlers:
   (GET  "/chsk" req (ring-ajax-get-or-ws-handshake req))
   (POST "/chsk" req (ring-ajax-post                req))
   )
+
+(def handler
+    (-> my-app
+        wrap-keyword-params
+        wrap-params))        ;; Add necessary ring middleware to your handler
+    
 ```
 
 > The `ring-ajax-post` and `ring-ajax-get-or-ws-handshake` fns will automatically handle Ring GET and POST requests to our channel socket URL (`"/chsk"`). Together these take care of the messy details of establishing + maintaining WebSocket or long-polling requests.


### PR DESCRIPTION
Since it is a requirement to have `wrap-params` and `wrap-keyword-params` for sente to work I thought it would be better if it was documented in the README.

Hope this helps