### PR TITLE
README fix: wherefore means why, not where.

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The [reference example project][] has a fully-baked example.
 
 You'll want to listen on the receive channel for a `[:chsk/state {:first-open? true}]` event. That's the signal that the socket's been established.
 
-#### Examples: wherefore art thou?
+#### Examples: where art thou?
 
 There's a full [reference example project][] in the repo. Call `lein start-dev` in that dir to get a (headless) development repl that you can connect to with [Cider][] (emacs) or your IDE.
 


### PR DESCRIPTION
http://www.oed.com/view/Entry/228218