### PR TITLE
Update version of clojure.tools.reader to 0.9.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   :dependencies
   [[org.clojure/clojure      "1.5.1"]
    [org.clojure/core.async   "0.1.346.0-17112a-alpha"]
-   [org.clojure/tools.reader "0.8.16"]
+   [org.clojure/tools.reader "0.9.2"]
    [com.taoensso/encore      "1.22.0"]
    [com.taoensso/timbre      "3.4.0"]]
 


### PR DESCRIPTION
Version of clojure.tool.reader from Sente's dependencies conflicts with the new version of ClojureScript:

"clojure.lang.ArityException: Wrong number of args (2) passed to: reader/read ..."

The full error message and discussion about it is here:
https://groups.google.com/forum/#!topic/clojurescript/UhmSvyQVJGg

