### PR TITLE
Add host-chsk-url-fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 > This project uses [Break Versioning](https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md) as of **Aug 16, 2014**.
 
+## v1.5.0 - 2015 Jun 11
+
+> This is a non-breaking maintenance release
+
+* **New**: support Ajax CORS via new `:with-credentials?` opt [#130 @bplatz]
+* **Fix**: bad missing-middleware error logging call format
+* **Implementation**: update dependencies
+
+
+```clojure
+[com.taoensso/sente "1.5.0"]
+```
+
+
 ## v1.4.1 - 2015 Mar 11
 
 > Trivial, non-breaking release that adds a pair of optional web-adapter aliases to help make examples a little simpler.

--- a/README.md
+++ b/README.md
@@ -265,6 +265,17 @@ Yup, it's automatic for both Ajax and WebSockets. If the page serving your JavaS
 
 Please see one of the [example projects][] for a fully-baked example.
 
+#### Cross Domain: How can I use Sente for cross domain connections?
+
+When you're making your connection in ClojureScript, use `host-chsk-url-fn` to specify the host to connect to, and provide it to `make-channel-socket`.
+
+```clj
+(sente/make-channel-socket! "/chsk"                   ; Note the same URL as before
+                                  {:type        chsk-type
+                                   :packer      packer
+                                   :chsk-url-fn (host-chsk-url-fn "myhost:1928")}) ;; Port is optional if connecting to standard ports
+```
+
 #### Pageload: How do I know when Sente is ready client-side?
 
 You'll want to listen on the receive channel for a `[:chsk/state {:first-open? true}]` event. That's the signal that the socket's been established.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **[API docs][]** | **[CHANGELOG][]** | [other Clojure libs][] | [Twitter][] | [contact/contrib](#contact--contributing) | current [Break Version][]:
 
 ```clojure
-[com.taoensso/sente "1.4.1"] ; BREAKS from v1.3.x, see CHANGELOG for details
+[com.taoensso/sente "1.5.0"] ; Stable, see CHANGELOG for details
 ```
 
 # Sente, channel sockets for Clojure
@@ -50,7 +50,7 @@ So you can ignore the underlying protocol and deal directly with Sente's unified
 Add the necessary dependency to your [Leiningen][] `project.clj`. This'll provide your project with both the client (ClojureScript) + server (Clojure) side library code:
 
 ```clojure
-[com.taoensso/sente "1.4.1"]
+[com.taoensso/sente "1.5.0"]
 ```
 
 ### On the server (Clojure) side

--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -995,7 +995,7 @@
     chsk))
 
 #+cljs
-(def default-chsk-url-fn
+(defn default-chsk-url-fn
   "(ƒ [path window-location websocket?]) -> server-side chsk route URL string.
 
     * path       - As provided to client-side `make-channel-socket!` fn
@@ -1013,9 +1013,9 @@
 
   Note that the *same* URL is used for: WebSockets, POSTs, GETs. Server-side
   routes should be configured accordingly."
-  (fn [path {:as window-location :keys [protocol host pathname]} websocket?]
-    (str (if-not websocket? protocol (if (= protocol "https:") "wss:" "ws:"))
-         "//" host (or path pathname))))
+  [path {:as window-location :keys [protocol host pathname]} websocket?]
+  (str (if-not websocket? protocol (if (= protocol "https:") "wss:" "ws:"))
+       "//" host (or path pathname)))
 
 #+cljs
 (defn make-channel-socket!

--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -1018,6 +1018,14 @@
        "//" host (or path pathname)))
 
 #+cljs
+(defn host-chsk-url-fn
+  "The same as default-chsk-url-fn but connects to the specified host instead of the
+  current web page host. Useful for cross domain channel sockets."
+  [host]
+  (fn my-chsk-url-fn [path loc ws?]
+    (default-chsk-url-fn path (assoc loc :host host) ws?)))
+
+#+cljs
 (defn make-channel-socket!
   "Returns a map with keys:
     :ch-recv ; core.async channel to receive `event-msg`s (internal or from clients).


### PR DESCRIPTION
It would be helpful for people using cross domain channel sockets to have a simplified `chsk-url-fn` for making connections to different hosts. This PR adds the function, and documentation on how to use it.