### PR TITLE
Tidy up conditional logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 > This project uses [Break Versioning](https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md) as of **Aug 16, 2014**.
 
+## v1.5.0 - 2015 Jun 11
+
+> This is a non-breaking maintenance release
+
+* **New**: support Ajax CORS via new `:with-credentials?` opt [#130 @bplatz]
+* **Fix**: bad missing-middleware error logging call format
+* **Implementation**: update dependencies
+
+
+```clojure
+[com.taoensso/sente "1.5.0"]
+```
+
+
 ## v1.4.1 - 2015 Mar 11
 
 > Trivial, non-breaking release that adds a pair of optional web-adapter aliases to help make examples a little simpler.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **[API docs][]** | **[CHANGELOG][]** | [other Clojure libs][] | [Twitter][] | [contact/contrib](#contact--contributing) | current [Break Version][]:
 
 ```clojure
-[com.taoensso/sente "1.4.1"] ; BREAKS from v1.3.x, see CHANGELOG for details
+[com.taoensso/sente "1.5.0"] ; Stable, see CHANGELOG for details
 ```
 
 # Sente, channel sockets for Clojure
@@ -50,7 +50,7 @@ So you can ignore the underlying protocol and deal directly with Sente's unified
 Add the necessary dependency to your [Leiningen][] `project.clj`. This'll provide your project with both the client (ClojureScript) + server (Clojure) side library code:
 
 ```clojure
-[com.taoensso/sente "1.4.1"]
+[com.taoensso/sente "1.5.0"]
 ```
 
 ### On the server (Clojure) side


### PR DESCRIPTION
Reading the Sente source I found a few places weren't clear, this PR reorders or reformats the conditional logic, while keeping the behaviour the same.

* Reorder conditional expressions to make logic more clear
* Reindent lines
* Split if's over 3 logical lines