### PR TITLE
Expose uid on ev-msg's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 > This project uses [Break Versioning](https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md) as of **Aug 16, 2014**.
 
+## v1.5.0 - 2015 Jun 11
+
+> This is a non-breaking maintenance release
+
+* **New**: support Ajax CORS via new `:with-credentials?` opt [#130 @bplatz]
+* **Fix**: bad missing-middleware error logging call format
+* **Implementation**: update dependencies
+
+
+```clojure
+[com.taoensso/sente "1.5.0"]
+```
+
+
 ## v1.4.1 - 2015 Mar 11
 
 > Trivial, non-breaking release that adds a pair of optional web-adapter aliases to help make examples a little simpler.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **[API docs][]** | **[CHANGELOG][]** | [other Clojure libs][] | [Twitter][] | [contact/contrib](#contact--contributing) | current [Break Version][]:
 
 ```clojure
-[com.taoensso/sente "1.4.1"] ; BREAKS from v1.3.x, see CHANGELOG for details
+[com.taoensso/sente "1.5.0"] ; Stable, see CHANGELOG for details
 ```
 
 # Sente, channel sockets for Clojure
@@ -50,7 +50,7 @@ So you can ignore the underlying protocol and deal directly with Sente's unified
 Add the necessary dependency to your [Leiningen][] `project.clj`. This'll provide your project with both the client (ClojureScript) + server (Clojure) side library code:
 
 ```clojure
-[com.taoensso/sente "1.4.1"]
+[com.taoensso/sente "1.5.0"]
 ```
 
 ### On the server (Clojure) side

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.taoensso/sente "1.5.0"
+(defproject com.taoensso/sente "1.5.1-SNAPSHOT"
   :author "Peter Taoussanis <https://www.taoensso.com>"
   :description "Clojure channel sockets library"
   :url "https://github.com/ptaoussanis/sente"

--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -174,9 +174,9 @@
     (map? x)
     (enc/keys= x #{:ch-recv :send-fn :connected-uids
                    :ring-req :client-id
-                   :event :id :?data :?reply-fn})
+                   :event :id :?data :?reply-fn :uid})
     (let [{:keys [ch-recv send-fn connected-uids
-                  ring-req client-id event ?reply-fn]} x]
+                  ring-req client-id event ?reply-fn uid]} x]
       (and
         (enc/chan?       ch-recv)
         (ifn?            send-fn)
@@ -186,7 +186,9 @@
         (enc/nblank-str? client-id)
         (event?          event)
         (or (nil? ?reply-fn)
-            (ifn? ?reply-fn))))))
+            (ifn? ?reply-fn))
+        ;; uid could be any value returned by user-id-fn
+        ))))
 
 #+clj
 (defn- put-event-msg>ch-recv!
@@ -454,7 +456,7 @@
           (fn [net-ch]
             (let [params        (get ring-req :params)
                   ppstr         (get params   :ppstr)
-                  ;; client-id  (get params   :client-id) ; Unnecessary here
+                  client-id     (get params   :client-id)
                   [clj has-cb?] (unpack packer ppstr)]
 
               (put-event-msg>ch-recv! ch-recv
@@ -462,6 +464,7 @@
                   {:client-id "unnecessary-for-non-lp-POSTs"
                    :ring-req  ring-req
                    :event     clj
+                   :uid (or (user-id-fn (assoc ring-req :client-id client-id)) ::nil-uid)
                    :?reply-fn
                    (when has-cb?
                      (fn reply-fn [resp-clj] ; Any clj form
@@ -496,7 +499,8 @@
                    {:client-id client-id
                     :ring-req  ring-req
                     :event     event
-                    :?reply-fn ?reply-fn})))
+                    :?reply-fn ?reply-fn
+                    :uid   uid})))
 
              handshake!
              (fn [net-ch]


### PR DESCRIPTION
It would be handy to be able to get the `uid` directly on the `ev-msg`. There are a few caveats though:

* I'm not sure how to get this for AJAX POST's (marked as a TODO in the commit)
* I'm not sure of the security implications of this. I think it's solid, because it's using the uid returned by `user-id-fn` on the server but I'd like some other minds on this too.

This isn't ready to merge yet, open for discussion :).