### PR TITLE
Add a run command to the example project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 > This project uses [Break Versioning](https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md) as of **Aug 16, 2014**.
 
+## v1.5.0 - 2015 Jun 11
+
+> This is a non-breaking maintenance release
+
+* **New**: support Ajax CORS via new `:with-credentials?` opt [#130 @bplatz]
+* **Fix**: bad missing-middleware error logging call format
+* **Implementation**: update dependencies
+
+
+```clojure
+[com.taoensso/sente "1.5.0"]
+```
+
+
 ## v1.4.1 - 2015 Mar 11
 
 > Trivial, non-breaking release that adds a pair of optional web-adapter aliases to help make examples a little simpler.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **[API docs][]** | **[CHANGELOG][]** | [other Clojure libs][] | [Twitter][] | [contact/contrib](#contact--contributing) | current [Break Version][]:
 
 ```clojure
-[com.taoensso/sente "1.4.1"] ; BREAKS from v1.3.x, see CHANGELOG for details
+[com.taoensso/sente "1.5.0"] ; Stable, see CHANGELOG for details
 ```
 
 # Sente, channel sockets for Clojure
@@ -50,7 +50,7 @@ So you can ignore the underlying protocol and deal directly with Sente's unified
 Add the necessary dependency to your [Leiningen][] `project.clj`. This'll provide your project with both the client (ClojureScript) + server (Clojure) side library code:
 
 ```clojure
-[com.taoensso/sente "1.4.1"]
+[com.taoensso/sente "1.5.0"]
 ```
 
 ### On the server (Clojure) side

--- a/example-project/src/example/my_app.cljx
+++ b/example-project/src/example/my_app.cljx
@@ -21,7 +21,6 @@
   LIGHT TABLE USERS:
     To configure Cljx support please see Ref. http://goo.gl/fKL5Z4."
   {:author "Peter Taoussanis"}
-
   #+clj
   (:require
    [clojure.string     :as str]
@@ -327,6 +326,10 @@
   (start-router!)
   #+clj (start-web-server!)
   #+clj (start-broadcaster!))
+
+
+(defn -main []
+  (start!))
 
 #+cljs   (start!)
 ;; #+clj (start!) ; Server-side auto-start disabled for LightTable, etc.


### PR DESCRIPTION
Adds a command to build the project and run it. Simplifies setting
up a working version for people who are not running compatible cider
setups, or who don't want to run it from there repl.