### PR TITLE
Remove extra ampersand from cljs make-channel-socket bindings

### DIFF
--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -990,7 +990,7 @@
     :ajax-opts      ; Base opts map provided to `taoensso.encore/ajax-lite`
     :wrap-recv-evs? ; Should events from server be wrapped in [:chsk/recv _]?"
   [path &
-   & [{:keys [type host recv-buf-or-n ws-kalive-ms lp-timeout-ms packer
+   [{:keys [type host recv-buf-or-n ws-kalive-ms lp-timeout-ms packer
               client-id ajax-opts wrap-recv-evs? backoff-ms-fn]
        :as   opts
        :or   {type          :auto


### PR DESCRIPTION
I think it's a fluke that destructuring with two &'s works in ClojureScript, it's not legal in Clojure. This patch removes the extra ampersand, and in the process fixes a bunch of resolution issues in Cursive Clojure.