### PR TITLE
Use timeouts for lp connections to prevent socket leaks [#150]

### DIFF
--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -1005,10 +1005,16 @@
                     ; application-level auth, etc.)
     :ws-kalive-ms   ; Ping to keep a WebSocket conn alive if no activity w/in given
                     ; number of milliseconds
-    :lp-timeout-ms  ; Ping to keep a long-polling (Ajax) conn alive ''
+    :lp-timeout-ms  ; Ping to keep a long-polling (Ajax) conn alive '' [1]
     :packer         ; :edn (default), or an IPacker implementation (experimental)
     :ajax-opts      ; Base opts map provided to `taoensso.encore/ajax-lite`
-    :wrap-recv-evs? ; Should events from server be wrapped in [:chsk/recv _]?"
+    :wrap-recv-evs? ; Should events from server be wrapped in [:chsk/recv _]?
+
+  [1] If you are using Immutant and override the default :lp-timeout-ms, you will
+      need provide the same value to
+      `taoensso.sente.server-adapters.immutant/make-immutant-adapter` and use the
+      result of that function as the web-server-adapter to your server-side
+      `make-channel-socket!`."
   [path &
    [{:keys [type host params recv-buf-or-n ws-kalive-ms lp-timeout-ms packer
               client-id ajax-opts wrap-recv-evs? backoff-ms-fn]

--- a/src/taoensso/sente/server_adapters/immutant.clj
+++ b/src/taoensso/sente/server_adapters/immutant.clj
@@ -11,7 +11,7 @@
   (send!* [im-ch msg close-after-send?]
     (immutant/send! im-ch msg {:close? close-after-send?})))
 
-(deftype ImmutantAsyncNetworkChannelAdapter []
+(deftype ImmutantAsyncNetworkChannelAdapter [lp-timeout-ms]
   i/IAsyncNetworkChannelAdapter
   (ring-req->net-ch-resp [net-ch-adapter ring-req callbacks-map]
     (let [{:keys [on-open on-msg on-close]} callbacks-map]
@@ -22,7 +22,22 @@
         :on-close    (when on-close
                        (fn [im-ch {:keys [code reason] :as status-map}]
                          (on-close im-ch status-map)))
-        :on-message  (when on-msg (fn [im-ch message] (on-msg im-ch message)))))))
+        :on-message  (when on-msg (fn [im-ch message] (on-msg im-ch message)))
+        :timeout     (if (:websocket? ring-req) 0 lp-timeout-ms)))))
 
-(def immutant-adapter (ImmutantAsyncNetworkChannelAdapter.))
+(defn make-immutant-adapter
+  "Creates an Immutant adapter.
+
+  Allows you to override the :lp-timeout-ms option, which specifies
+  server-side timeout for long-polling connections. If you override the
+  :lp-timeout-ms option in yourclient-side call to
+  `make-channel-socket!`, you'll need to provide that same value
+  here. If you aren't customizing the client-side :lp-timeout-ms, you
+  can safely use the default Immutant adapter (`immutant-adapter` or
+  `sente-web-server-adapter`). "
+  [{:keys [lp-timeout-ms]
+    :or   {lp-timeout-ms 25000}}]
+  (ImmutantAsyncNetworkChannelAdapter. lp-timeout-ms))
+
+(def immutant-adapter (make-immutant-adapter nil))
 (def sente-web-server-adapter immutant-adapter) ; Alias for ns import convenience


### PR DESCRIPTION
This sets a timeout on the server-side for long-polling connections
so they get cleaned up when the client closes as part of its standard
ping mechanism or goes away.

This requires a recent Immutant incremental
build (http://immutant.org/builds/2x/) or Immutant 2.1.0, once it is
released.