### PR TITLE
Added support for Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,15 +154,15 @@ The client will automatically initiate a WebSocket or repeating long-polling con
 
 ===============
 
-Term          | Form                                                                  |
-------------- | --------------------------------------------------------------------- |
-**event**     | `[<ev-id> <?ev-data>]`, e.g. `[:my-app/some-req {:data "data"}]`      |
-**event-msg** (server) | `{:event _ :send-fn _ :?reply-fn _ :ring-req _ <...>}`       |
-**event-msg** (client) | `{:event _ :send-fn _ <...>}`                                |
-`<ev-id>`     | A _namespaced_ keyword like `:my-app/some-req`                        |
-`<?ev-data>`  | An optional _arbitrary edn value_ like `{:data "data"}`               |
-`:ring-req`   | Ring map for Ajax request or WebSocket's initial handshake request    |
-`:?reply-fn`  | Present only when client requested a reply.                           |
+Term          | Form                                                                   |
+------------- | ---------------------------------------------------------------------- |
+event         | `[<ev-id> <?ev-data>]`, e.g. `[:my-app/some-req {:data "data"}]`       |
+server event-msg | `{:keys [event id ?data send-fn ?reply-fn uid ring-req client-id]}` |
+client event-msg | `{:keys [event id ?data send-fn]}`                                  |
+`<ev-id>`     | A _namespaced_ keyword like `:my-app/some-req`                         |
+`<?ev-data>`  | An optional _arbitrary edn value_ like `{:data "data"}`                |
+`:ring-req`   | Ring map for Ajax request or WebSocket's initial handshake request     |
+`:?reply-fn`  | Present only when client requested a reply.                            |
 
 #### Summary
 

--- a/example-project/project.clj
+++ b/example-project/project.clj
@@ -21,7 +21,8 @@
    [com.taoensso/timbre       "4.1.1"]
 
    ;;; ---> Choose (uncomment) a supported web server <---
-   [http-kit                  "2.1.19"]
+   [org.clojars.whamtet/dogfort "0.2.0-SNAPSHOT"]
+   ;; [http-kit                  "2.1.19"]
    ;; [org.immutant/web       "2.1.0"] ; v2.1+ recommended
    ;; [nginx-clojure/nginx-clojure-embed "0.4.2"] ; Needs v0.4.2+
 
@@ -44,6 +45,7 @@
    [com.keminglabs/cljx "0.6.0"]
    [lein-cljsbuild      "1.1.0"]
    [cider/cider-nrepl   "0.8.2"] ; Optional, for use with Emacs
+   [lein-npm "0.6.1"]
    ]
 
   :prep-tasks [["cljx" "once"] "javac" "compile"]
@@ -58,7 +60,15 @@
      :source-paths ["src" "target/classes"]
      :compiler     {:output-to "resources/public/main.js"
                     :optimizations :whitespace #_:advanced
-                    :pretty-print true}}]}
+                    :pretty-print true}}
+    {:id "dogfort"
+     :source-paths ["src" "target/classes"]
+     :compiler {:output-to "main.js"
+                :main example.my-app-node
+                :target :nodejs
+                :output-dir "out"
+                }}
+    ]}
 
   ;; Call `lein start-dev` to get a (headless) development repl that you can
   ;; connect to with Cider+emacs or your IDE of choice:

--- a/example-project/src/example/my_app_node.cljs
+++ b/example-project/src/example/my_app_node.cljs
@@ -1,0 +1,209 @@
+(ns example.my-app-node
+  "Sente client+server reference web-app example.
+  Uses Kevin Lynagh's awesome Cljx Leiningen plugin,
+  Ref. https://github.com/lynaghk/cljx
+
+  ------------------------------------------------------------------------------
+  This example dives into Sente's full functionality quickly; it's probably
+  more useful as a reference than a tutorial. See the GitHub README for a
+  gentler intro.
+  ------------------------------------------------------------------------------
+
+  Instructions:
+  1. Call `lein start-dev` at your terminal.
+  2. Connect to development nREPL (port will be printed).
+  3. Evaluate this namespace (M-x `cider-load-current-buffer` for CIDER+Emacs).
+  4. Evaluate `(start!)` in this namespace (M-x `cider-eval-last-sexp` for
+  CIDER+Emacs).
+  5. Open browser & point to local web server (port will be printed).
+  6. Observe browser's console + nREPL's std-out.
+
+  Light Table users:
+  To configure Cljx support please see Ref. http://goo.gl/fKL5Z4."
+
+  {:author "Peter Taoussanis, and contributors"}
+
+  (:require
+   [clojure.string     :as str]
+   [cljs.core.async :as async  :refer (<!)]
+   [taoensso.encore    :as encore :refer ()]
+   [taoensso.timbre    :as timbre :refer-macros (tracef debugf infof warnf errorf)]
+   [taoensso.sente-node     :as sente]
+   [hiccups.runtime]
+
+   ;;; ---> Choose (uncomment) a supported web server and adapter <---
+   [dogfort.middleware.defaults :as defaults]
+   [dogfort.middleware.routes]
+   [taoensso.sente.server-adapters.dogfort :refer (sente-web-server-adapter)]
+
+   ;; Optional, for Transit encoding:
+   [taoensso.sente.packers.transit :as sente-transit])
+
+  (:use [dogfort.http :only [run-http]])
+  (:require-macros [hiccups.core :as hiccups]
+                   [cljs.core.async.macros :as asyncm :refer (go go-loop)]
+                   )
+  (:use-macros [dogfort.middleware.routes-macros :only [defroutes GET POST]])
+  )
+
+(defn start-web-server!* [ring-handler port]
+  (println "Starting dogfort...")
+  (run-http ring-handler {:port port}))
+
+;;;; Packer (client<->server serializtion format) config
+
+(def packer (sente-transit/get-flexi-packer :edn)) ; Experimental, needs Transit dep
+;; (def packer :edn) ; Default packer (no need for Transit dep)
+
+;;;; Server-side setup
+
+(let [{:keys [ch-recv send-fn ajax-post-fn ajax-get-or-ws-handshake-fn
+              connected-uids]}
+      (sente/make-channel-socket! sente-web-server-adapter {:packer packer})]
+  (def ring-ajax-post                ajax-post-fn)
+  (def ring-ajax-get-or-ws-handshake ajax-get-or-ws-handshake-fn)
+  (def ch-chsk                       ch-recv) ; ChannelSocket's receive channel
+  (def chsk-send!                    send-fn) ; ChannelSocket's send API fn
+  (def connected-uids                connected-uids) ; Watchable, read-only atom
+  )
+
+(defn landing-pg-handler [req]
+  (hiccups/html5
+   [:h1 "Sente reference example"]
+   [:p "An Ajax/WebSocket connection has been configured (random)."]
+   [:hr]
+   [:p [:strong "Step 1: "] "Open browser's JavaScript console."]
+   [:p [:strong "Step 2: "] "Try: "
+    [:button#btn1 {:type "button"} "chsk-send! (w/o reply)"]
+    [:button#btn2 {:type "button"} "chsk-send! (with reply)"]]
+   ;;
+   [:p [:strong "Step 3: "] "See browser's console + nREPL's std-out." ]
+   ;;
+   [:hr]
+   [:h2 "Login with a user-id"]
+   [:p  "The server can use this id to send events to *you* specifically."]
+   [:p [:input#input-login {:type :text :placeholder "User-id"}]
+    [:button#btn-login {:type "button"} "Secure login!"]]
+   [:script {:src "main.js"}] ; Include our cljs target
+   ))
+
+
+(defn login!
+  "Here's where you'll add your server-side login/auth procedure (Friend, etc.).
+  In our simplified example we'll just always successfully authenticate the user
+  with whatever user-id they provided in the auth request."
+  [ring-request]
+  (let [{:keys [session params]} ring-request
+        {:keys [user-id]} params]
+    (debugf "Login request: %s" params)
+    {:status 200 :session (assoc session :uid user-id)}))
+
+
+(defroutes my-routes
+  (GET  "/"      req (landing-pg-handler req))
+  ;;
+  (GET  "/chsk"  req (ring-ajax-get-or-ws-handshake req))
+  (POST "/chsk"  req (ring-ajax-post                req))
+  (POST "/login" req (login! req)))
+
+(def my-ring-handler
+  (defaults/wrap-defaults my-routes {:wrap-file "resources/public"}))
+
+;;;; Routing handlers
+
+;; So you'll want to define one server-side and one client-side
+;; (fn event-msg-handler [ev-msg]) to correctly handle incoming events. How you
+;; actually do this is entirely up to you. In this example we use a multimethod
+;; that dispatches to a method based on the `event-msg`'s event-id. Some
+;; alternatives include a simple `case`/`cond`/`condp` against event-ids, or
+;; `core.match` against events.
+
+(defmulti event-msg-handler :id) ; Dispatch on event-
+
+;; Wrap for logging, catching, etc.:
+(defn     event-msg-handler* [{:as ev-msg :keys [id ?data event]}]
+  (debugf "Event: %s" event)
+  (event-msg-handler ev-msg))
+
+
+(do ; Server-side methods
+  (defmethod event-msg-handler :default ; Fallback
+    [{:as ev-msg :keys [event id ?data ring-req ?reply-fn send-fn]}]
+    (let [session (:session ring-req)
+          uid     (:uid     session)]
+      (prn "Unhandled event:" event)
+      (when ?reply-fn
+        (?reply-fn {:umatched-event-as-echoed-from-from-server event}))))
+
+  ;; Add your (defmethod event-msg-handler <event-id> [ev-msg] <body>)s here...
+  )
+
+;;;; Example: broadcast server>user
+
+;; As an example of push notifications, we'll setup a server loop to broadcast
+;; an event to _all_ possible user-ids every 10 seconds:
+
+(defn start-broadcaster! []
+  (go-loop [i 0]
+           (<! (async/timeout 10000))
+           (println (str "Broadcasting server>user: " @connected-uids))
+           (doseq [uid (:any @connected-uids)]
+             (chsk-send! uid
+                         [:some/broadcast
+                          {:what-is-this "A broadcast pushed from server"
+                           :how-often    "Every 10 seconds"
+                           :to-whom uid
+                           :i i}]))
+           (recur (inc i))))
+
+; Note that this'll be fast+reliable even over Ajax!:
+(defn test-fast-server>user-pushes []
+  (doseq [uid (:any @connected-uids)]
+    (doseq [i (range 100)]
+      (chsk-send! uid [:fast-push/is-fast (str "hello " i "!!")]))))
+
+(comment (test-fast-server>user-pushes))
+
+;;;; Init
+
+(defonce web-server_ (atom nil)) ; {:server _ :port _ :stop-fn (fn [])}
+;(defn stop-web-server! [] (when-let [m @web-server_] ((:stop-fn m))))
+
+(defn start-web-server! []
+  (start-web-server!* my-ring-handler 5000))
+
+#_(defn start-web-server! [& [port]]
+;  (stop-web-server!)
+  (let [{:keys [stop-fn port] :as server-map}
+        (start-web-server!* (var my-ring-handler)
+                            (or port 0) ; 0 => auto (any available) port
+                            )
+        uri (str "http://localhost:" port "/")]
+    (debugf "Web server is running at `%s`" uri)
+    (try
+      (.browse (java.awt.Desktop/getDesktop) (java.net.URI. uri))
+      (catch java.awt.HeadlessException _))
+    (reset! web-server_ server-map)))
+
+(defonce router_ (atom nil))
+
+(defn  stop-router! [] (when-let [stop-f @router_] (stop-f)))
+(defn start-router! []
+  (stop-router!)
+  (reset! router_ (sente/start-chsk-router! ch-chsk event-msg-handler*)))
+
+(defn start! []
+  (start-router!)
+  (start-web-server!)
+  (start-broadcaster!))
+
+(defn -main [] (start!)) ; For `lein run`, etc.
+
+
+;; #+clj (start!) ; Server-side auto-start disabled for LightTable, etc.
+(comment (start!)
+  (test-fast-server>user-pushes))
+
+(set! *main-cli-fn* start!)
+
+;;;;;;;;;;;; This file autogenerated from src/example/my_app.cljx

--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,11 @@
    [com.taoensso/encore      "2.15.0"]
    [com.taoensso/timbre      "4.1.1"]]
 
+  :plugins [[lein-npm "0.6.1"]]
+
+  :npm {:dependencies []}
+>>>>>>> Added node support
+
   :profiles
   {;; :default [:base :system :user :provided :dev]
    :server-jvm {:jvm-opts ^:replace ["-server"]}
@@ -39,6 +44,10 @@
     {:dependencies
      [[http-kit                        "2.1.19"]
       [org.immutant/web                "2.1.0"]
+<<<<<<< HEAD
+=======
+      [org.clojars.whamtet/dogfort "0.2.0-SNAPSHOT"]
+>>>>>>> Added node support
       [nginx-clojure                   "0.4.2"]]
      :plugins
      [;;; These must be in :dev, Ref. https://github.com/lynaghk/cljx/issues/47:
@@ -51,7 +60,8 @@
       [lein-expectations               "0.0.8"]
       [lein-autoexpect                 "1.4.2"]
       [com.cemerick/clojurescript.test "0.3.3"]
-      [codox                           "0.8.11"]]}]}
+      [codox                           "0.8.11"]]
+     }]}
 
   :cljx
   {:builds
@@ -66,7 +76,25 @@
      :source-paths ["src" "test" "target/classes"]
      :compiler     {:output-to "target/main.js"
                     :optimizations :advanced
-                    :pretty-print false}}]}
+                    :pretty-print false}}
+
+    ;need additional build tasks because we're targeting node.js to test the dogfort extension
+    ;by default cljsbuild will run both tasks at once
+    ;to run a single task type `cljsbuild auto <task>`
+
+    {:id "dogfort"
+     :source-paths ["src" "test" "target/classes"]
+     :compiler {:output-to "main.js"
+                :main taoensso.sente.tests.dogfort
+                :target :nodejs
+                :output-dir "out"
+                }}
+
+    {:id "client"
+     :source-paths ["src" "test" "target/classes"]
+     :compiler {:output-to "public/client/main.js"
+                :output-dir "public/client"}}
+    ]}
 
   :test-paths ["test" "src"]
   :prep-tasks [["cljx" "once"] "javac" "compile"]
@@ -82,7 +110,9 @@
    "test-auto"  ["with-profile" "+test" "autoexpect"]
    "build-once" ["do" "cljx" "once," "cljsbuild" "once"]
    "deploy-lib" ["do" "build-once," "deploy" "clojars," "install"]
-   "start-dev"  ["with-profile" "+server-jvm" "repl" ":headless"]}
+   "start-dev"  ["with-profile" "+server-jvm" "repl" ":headless"]
+   "test-dogfort" ["with-profile" "+provided,+dev" "cljsbuild" "auto" "dogfort" "client"]
+   }
 
   :repositories
   {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"})

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   [[org.clojure/clojure      "1.5.1"]
    [org.clojure/core.async   "0.1.346.0-17112a-alpha"]
    [org.clojure/tools.reader "0.9.2"]
-   [com.taoensso/encore      "2.6.5"]
+   [com.taoensso/encore      "2.15.0"]
    [com.taoensso/timbre      "4.1.1"]]
 
   :profiles
@@ -26,7 +26,7 @@
    :test {:dependencies [[com.cognitect/transit-clj  "0.8.281"]
                          [com.cognitect/transit-cljs "0.8.225"]
                          [expectations               "2.1.0"]
-                         [org.clojure/test.check     "0.7.0"]
+                         [org.clojure/test.check     "0.8.2"]
                          ;; [com.cemerick/double-check "0.6.1"]
                          ]
           :plugins [[lein-expectations "0.0.8"]

--- a/project.clj
+++ b/project.clj
@@ -36,14 +36,14 @@
 
    :dev
    [:1.7 :test
-    {:plugins
+    {:dependencies
+     [[http-kit                        "2.1.19"]
+      [org.immutant/web                "2.1.0"]
+      [nginx-clojure                   "0.4.2"]]
+     :plugins
      [;;; These must be in :dev, Ref. https://github.com/lynaghk/cljx/issues/47:
       [com.keminglabs/cljx             "0.5.0"]
       [lein-cljsbuild                  "1.1.0"]
-      ;;
-      [http-kit                        "2.1.19"]
-      [org.immutant/web                "2.1.0"]
-      [nginx-clojure                   "0.4.2"]
       ;;
       [lein-pprint                     "1.1.1"]
       [lein-ancient                    "0.6.7"]

--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -79,18 +79,9 @@
   (:require-macros
    [cljs.core.async.macros :as asyncm :refer (go go-loop)]))
 
-;;;; Encore version check
-
-#+clj
-(let [min-encore-version 2.4]
-  (if-let [assert! (ns-resolve 'taoensso.encore 'assert-min-encore-version)]
-    (assert! min-encore-version)
-    (throw
-      (ex-info
-        (format
-          "Insufficient com.taoensso/encore version (< %s). You may have a Leiningen dependency conflict (see http://goo.gl/qBbLvC for solution)."
-          min-encore-version)
-        {:min-version min-encore-version}))))
+(if (vector? taoensso.encore/encore-version)
+  (encore/assert-min-encore-version [2 11 0])
+  (encore/assert-min-encore-version  2.11))
 
 ;;;; Events
 ;; * Clients & server both send `event`s and receive (i.e. route) `event-msg`s.

--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -165,9 +165,9 @@
       (warnf "Bad ev-msg: %s" ev-msg) ; Log 'n drop
       (put! ch-recv ev-msg*))))
 
-#+cljs
-(defn cb-success? "Note that cb reply need _not_ be `event` form!"
-  [cb-reply-clj] (not (#{:chsk/closed :chsk/timeout :chsk/error} cb-reply-clj)))
+;;; Note that cb replys need _not_ be `event` form!
+#+cljs (defn cb-error?   [cb-reply-clj] (#{:chsk/closed :chsk/timeout :chsk/error} cb-reply-clj))
+#+cljs (defn cb-success? [cb-reply-clj] (not (cb-error? cb-reply-clj)))
 
 ;;;; Packing
 ;; * Client<->server payloads are arbitrary Clojure vals (cb replies or events).

--- a/src/taoensso/sente/interfaces.cljx
+++ b/src/taoensso/sente/interfaces.cljx
@@ -6,7 +6,6 @@
 
 ;;;; Network channels
 
-#+clj
 (defprotocol IAsyncNetworkChannel
   ;; Wraps a web server's own async channel/comms interface to abstract away
   ;; implementation differences
@@ -14,25 +13,24 @@
   (open?  [net-ch] "Returns true iff the channel is currently open.")
   (close! [net-ch] "Closes the channel."))
 
-#+clj (defn send! [net-ch msg & [close-after-send?]]
-        (send!* net-ch msg close-after-send?))
+(defn send! [net-ch msg & [close-after-send?]]
+  (send!* net-ch msg close-after-send?))
 
-#+clj
 (defprotocol IAsyncNetworkChannelAdapter
   ;; Wraps a web server's own Ring-request->async-channel-response interface to
   ;; abstract away implementation differences
   (ring-req->net-ch-resp [net-ch-adapter ring-req callbacks-map]
-    "Given a Ring request (WebSocket handshake or Ajax GET/POST), returns a Ring
-    response map with a web-server-specific channel :body that implements
-    Sente's IAsyncNetworkChannel protocol.
+                         "Given a Ring request (WebSocket handshake or Ajax GET/POST), returns a Ring
+                         response map with a web-server-specific channel :body that implements
+                         Sente's IAsyncNetworkChannel protocol.
 
-    Configures channel callbacks with a callbacks map using keys:
-      :on-open  - (fn [net-ch]) called exactly once after channel is available
-                  for sending.
-      :on-close - (fn [net-ch status]) called exactly once after channel is
-                  closed for ANY cause, incl. a call to `close!`.
-      :on-msg   - (fn [net-ch msg]) called for each String or byte[] message
-                  received from client. Currently only used for WebSocket clients."))
+                         Configures channel callbacks with a callbacks map using keys:
+                         :on-open  - (fn [net-ch]) called exactly once after channel is available
+                         for sending.
+                         :on-close - (fn [net-ch status]) called exactly once after channel is
+                         closed for ANY cause, incl. a call to `close!`.
+                         :on-msg   - (fn [net-ch msg]) called for each String or byte[] message
+                         received from client. Currently only used for WebSocket clients."))
 
 ;;;; Packers
 

--- a/src/taoensso/sente/server_adapters/dogfort.cljs
+++ b/src/taoensso/sente/server_adapters/dogfort.cljs
@@ -1,0 +1,78 @@
+(ns taoensso.sente.server-adapters.dogfort
+  "Sente on node.js with dogfort (https://github.com/whamtet/dogfort)"
+  {:author "Matthew Molloy (whamtet@gmail.com)"}
+  (:require [taoensso.sente.interfaces :as i]))
+
+(def
+  "we handle two cases: ajax and websocket."
+  sente-web-server-adapter
+  (reify
+    i/IAsyncNetworkChannelAdapter
+    (ring-req->net-ch-resp
+     [_ ring-req callbacks-map]
+     (let [
+           {:keys [on-open on-close on-msg]} callbacks-map
+           {:keys [websocket response body]} ring-req
+           response-open? (atom true)
+           write #(try
+                    (.write %1 %2)
+                    (catch :default e))
+           chan
+           (if websocket
+
+             (reify i/IAsyncNetworkChannel
+               (send!* [this msg close-after-send?]
+                       "Sends a message to channel."
+                       (let [
+                             pre-open? (= (.-readyState websocket) (.-OPEN websocket))
+                             ]
+                         (.send websocket msg)
+                         (when close-after-send?
+                           (.close websocket))
+                         pre-open?))
+               (open?  [net-ch]
+                       "Returns true iff the channel is currently open."
+                       (= (.-readyState websocket) (.-OPEN websocket)))
+               (close! [net-ch] "Closes the channel."
+                       (.close websocket)))
+
+             (reify i/IAsyncNetworkChannel
+               (send!* [this msg close-after-send?]
+                       (let [
+                             pre-open? @response-open?
+                             ]
+                         (if close-after-send?
+                           (do
+                             (reset! response-open? false)
+                             (.end response msg))
+                           (write response msg))
+                         pre-open?))
+               (open? [this] @response-open?)
+               (close! [this]
+                       (if @response-open?
+                         (.end response))
+                       (reset! response-open? false))))
+           ]
+       (on-open chan)
+       (if websocket
+         (do
+           (.on websocket
+                "message"
+                (fn [data flags]
+                  (on-msg chan data)))
+           (.onclose websocket
+                     (fn [code message]
+                       (on-close chan code))))
+         (do
+           (.on body "data"
+                (fn [data]
+                  (on-msg chan data)))
+           #_(.on response ;bad, bad!
+                "finish"
+                #(on-close chan))))
+
+       ;;for ajax connections if we reply blank then the route matcher will fail.
+       ;;dogfort will send a 404 response and close the connection.
+       ;;to keep it open we just send this instead of a ring response.
+       {:keep-alive true}
+       ))))

--- a/src/taoensso/sente_node.cljs
+++ b/src/taoensso/sente_node.cljs
@@ -1,0 +1,590 @@
+(ns taoensso.sente-node
+  "The server code for sente adapter for node.js"
+  (:require
+   [clojure.string     :as str]
+   [cljs.core.async :as async  :refer (put! chan)]
+   [taoensso.encore    :as enc    :refer (swap-in! reset-in! swapped)]
+   [taoensso.timbre]
+   [taoensso.sente.interfaces :as interfaces]
+   )
+  (:require-macros [taoensso.encore :refer (have have?)]
+                   [taoensso.timbre :as timbre :refer (tracef debugf infof warnf errorf)]
+                   [cljs.core.async.macros :refer [go go-loop]])
+  )
+
+;; ;;;; Events
+;; ;; * Clients & server both send `event`s and receive (i.e. route) `event-msg`s.
+
+(defn- validate-event [x]
+  (cond
+   (not (vector? x))        :wrong-type
+   (not (#{1 2} (count x))) :wrong-length
+   :else (let [[ev-id _] x]
+           (cond (not (keyword? ev-id))  :wrong-id-type
+                 (not (namespace ev-id)) :unnamespaced-id
+                 :else nil))))
+
+(defn event? "Valid [ev-id ?ev-data] form?" [x] (nil? (validate-event x)))
+
+(defn as-event [x] (if (event? x) x [:chsk/bad-event x]))
+
+(defn format [s t]
+  (.replace s "%s" t))
+
+(defn assert-event [x]
+  (when-let [?err (validate-event x)]
+    (let [err-fmt
+          (str
+           (case ?err
+             :wrong-type   "Malformed event (wrong type)."
+             :wrong-length "Malformed event (wrong length)."
+             (:wrong-id-type :unnamespaced-id)
+             "Malformed event (`ev-id` should be a namespaced keyword)."
+             :else "Malformed event (unknown error).")
+           " Event should be of `[ev-id ?ev-data]` form: %s")]
+      (throw (ex-info (format err-fmt (str x)) {:malformed-event x})))))
+
+(defn event-msg? [x]
+  (and
+   (map? x)
+   (enc/keys= x #{:ch-recv :send-fn :connected-uids
+                  :ring-req :client-id
+                  :event :id :?data :?reply-fn :uid})
+   (let [{:keys [ch-recv send-fn connected-uids
+                 ring-req client-id event ?reply-fn]} x]
+     (and
+      (enc/chan?       ch-recv)
+      (ifn?            send-fn)
+      (enc/atom?       connected-uids)
+      ;;
+      (map?            ring-req)
+      (enc/nblank-str? client-id)
+      (event?          event)
+      (or (nil? ?reply-fn)
+          (ifn? ?reply-fn))))))
+
+
+(defn- put-event-msg>ch-recv!
+  "All server-side `event-msg`s go through this."
+  [ch-recv {:as ev-msg :keys [event ?reply-fn]}]
+  (let [[ev-id ev-?data :as valid-event] (as-event event)
+        ev-msg* (merge ev-msg {:event     valid-event
+                               :?reply-fn ?reply-fn
+                               :id        ev-id
+                               :?data     ev-?data})]
+    (if-not (event-msg? ev-msg*)
+      (warnf "Bad ev-msg: %s" ev-msg) ; Log 'n drop
+      (put! ch-recv ev-msg*))))
+
+;; ;;;; Packing
+;; ;; * Client<->server payloads are arbitrary Clojure vals (cb replies or events).
+;; ;; * Payloads are packed for client<->server transit.
+;; ;; * Packing includes ->str encoding, and may incl. wrapping to carry cb info.
+
+(defn- unpack* "pstr->clj" [packer pstr]
+  (try
+    (interfaces/unpack packer (have string? pstr))
+    (catch :default t
+      (debugf "Bad package: %s (%s)" pstr t)
+      [:chsk/bad-package pstr]
+      ; Let client rethrow on bad pstr from server
+      )))
+
+(defn- with-?meta [x ?m] (if (seq ?m) (with-meta x ?m) x))
+
+(defn- pack* "clj->prefixed-pstr"
+  ([packer ?packer-meta clj]
+   (str "-" ; => Unwrapped (no cb metadata)
+        (interfaces/pack packer (with-?meta clj ?packer-meta))))
+
+  ([packer ?packer-meta clj ?cb-uuid]
+   (let [;;; Keep wrapping as light as possible:
+         ?cb-uuid    (if (= ?cb-uuid :ajax-cb) 0 ?cb-uuid)
+         wrapped-clj (if ?cb-uuid [clj ?cb-uuid] [clj])]
+     (str "+" ; => Wrapped (cb metadata)
+          (interfaces/pack packer (with-?meta wrapped-clj ?packer-meta))))))
+
+(defn- pack [& args]
+  (let [pstr (apply pack* args)]
+    (tracef "Packing: %s -> %s" args pstr)
+    pstr))
+
+(defn- unpack "prefixed-pstr->[clj ?cb-uuid]"
+  [packer prefixed-pstr]
+  (have? string? prefixed-pstr)
+  (let [prefix   (enc/substr prefixed-pstr 0 1)
+        pstr     (enc/substr prefixed-pstr 1)
+        clj      (unpack* packer pstr) ; May be un/wrapped
+        wrapped? (case prefix "-" false "+" true)
+        [clj ?cb-uuid] (if wrapped? clj [clj nil])
+        ?cb-uuid (if (= 0 ?cb-uuid) :ajax-cb ?cb-uuid)]
+    (tracef "Unpacking: %s -> %s" prefixed-pstr [clj ?cb-uuid])
+    [clj ?cb-uuid]))
+
+;; (comment
+;;   (do (require '[taoensso.sente.packers.transit :as transit])
+;;       (def edn-packer   interfaces/edn-packer)
+;;       (def flexi-packer (transit/get-flexi-packer)))
+;;   (unpack edn-packer   (pack edn-packer   nil          "hello"))
+;;   (unpack flexi-packer (pack flexi-packer nil          "hello"))
+;;   (unpack flexi-packer (pack flexi-packer {}           [:foo/bar {}] "my-cb-uuid"))
+;;   (unpack flexi-packer (pack flexi-packer {:json true} [:foo/bar {}] "my-cb-uuid"))
+;;   (unpack flexi-packer (pack flexi-packer {}           [:foo/bar {}] :ajax-cb)))
+
+;; ;;;; Server API
+
+(declare ^:private send-buffered-evs>ws-clients!
+         ^:private send-buffered-evs>ajax-clients!)
+
+
+(defn make-channel-socket!
+  "Takes a web server adapter[1] and returns a map with keys:
+  :ch-recv ; core.async channel to receive `event-msg`s (internal or from clients).
+  :send-fn ; (fn [user-id ev] for server>user push.
+  :ajax-post-fn                ; (fn [ring-req]) for Ring CSRF-POST + chsk URL.
+  :ajax-get-or-ws-handshake-fn ; (fn [ring-req]) for Ring GET + chsk URL.
+  :connected-uids ; Watchable, read-only (atom {:ws #{_} :ajax #{_} :any #{_}}).
+
+  Common options:
+  :user-id-fn        ; (fn [ring-req]) -> unique user-id for server>user push.
+  :csrf-token-fn     ; (fn [ring-req]) -> CSRF token for Ajax POSTs.
+  :handshake-data-fn ; (fn [ring-req]) -> arb user data to append to handshake evs.
+  :send-buf-ms-ajax  ; [2]
+  :send-buf-ms-ws    ; [2]
+  :packer            ; :edn (default), or an IPacker implementation (experimental).
+
+  [1] e.g. `taoensso.sente.server-adapters.http-kit/http-kit-adapter` or
+  `taoensso.sente.server-adapters.immutant/immutant-adapter`.
+  You must have the necessary web-server dependency in your project.clj and
+  the necessary entry in your namespace's `ns` form.
+
+  [2] Optimization to allow transparent batching of rapidly-triggered
+  server>user pushes. This is esp. important for Ajax clients which use a
+  (slow) reconnecting poller. Actual event dispatch may occur <= given ms
+  after send call (larger values => larger batch windows)."
+
+  [web-server-adapter ; Actually a net-ch-adapter, but that may be confusing
+   & [{:keys [recv-buf-or-n send-buf-ms-ajax send-buf-ms-ws
+              user-id-fn csrf-token-fn handshake-data-fn packer]
+       :or   {recv-buf-or-n (async/sliding-buffer 1000)
+              send-buf-ms-ajax 100
+              send-buf-ms-ws   30
+              user-id-fn    (fn [ring-req] (get-in ring-req [:session :uid]))
+              csrf-token-fn (fn [ring-req]
+                              (or (get-in ring-req [:session :csrf-token])
+                                  (get-in ring-req [:session :ring.middleware.anti-forgery/anti-forgery-token])
+                                  (get-in ring-req [:session "__anti-forgery-token"])))
+              handshake-data-fn (fn [ring-req] nil)
+              packer :edn}}]]
+
+  {:pre [(have? enc/pos-int? send-buf-ms-ajax send-buf-ms-ws)
+         (have? #(satisfies? interfaces/IAsyncNetworkChannelAdapter %)
+                web-server-adapter)]}
+
+  (let [packer  (interfaces/coerce-packer packer)
+        ch-recv (chan recv-buf-or-n)
+        conns_  (atom {:ws   {} ; {<uid> {<client-id> <net-ch>}}
+                       :ajax {} ; {<uid> {<client-id> [<?net-ch> <udt-last-connected>]}}
+                       })
+        connected-uids_ (atom {:ws #{} :ajax #{} :any #{}})
+        send-buffers_   (atom {:ws  {} :ajax  {}}) ; {<uid> [<buffered-evs> <#{ev-uuids}>]}
+
+        user-id-fn
+        (fn [ring-req client-id]
+          ;; Allow uid to depend (in part or whole) on client-id. Be cautious
+          ;; of security implications.
+          (or (user-id-fn (assoc ring-req :client-id client-id)) ::nil-uid))
+
+        connect-uid!
+        (fn [type uid] {:pre [(have? uid)]}
+          (let [newly-connected?
+                (swap-in! connected-uids_ []
+                          (fn [{:keys [ws ajax any] :as old-m}]
+                            (let [new-m
+                                  (case type
+                                    :ws   {:ws (conj ws uid) :ajax ajax            :any (conj any uid)}
+                                    :ajax {:ws ws            :ajax (conj ajax uid) :any (conj any uid)})]
+                              (swapped new-m
+                                       (let [old-any (:any old-m)
+                                             new-any (:any new-m)]
+                                         (when (and (not (contains? old-any uid))
+                                                    (contains? new-any uid))
+                                           :newly-connected))))))]
+            newly-connected?))
+
+        upd-connected-uid! ; Useful for atomic disconnects
+        (fn [uid] {:pre [(have? uid)]}
+          (let [newly-disconnected?
+                (swap-in! connected-uids_ []
+                          (fn [{:keys [ws ajax any] :as old-m}]
+                            (let [conns' @conns_
+                                  any-ws-clients?   (contains? (:ws   conns') uid)
+                                  any-ajax-clients? (contains? (:ajax conns') uid)
+                                  any-clients?      (or any-ws-clients?
+                                                        any-ajax-clients?)
+                                  new-m
+                                  {:ws   (if any-ws-clients?   (conj ws   uid) (disj ws   uid))
+                                   :ajax (if any-ajax-clients? (conj ajax uid) (disj ajax uid))
+                                   :any  (if any-clients?      (conj any  uid) (disj any  uid))}]
+                              (swapped new-m
+                                       (let [old-any (:any old-m)
+                                             new-any (:any new-m)]
+                                         (when (and      (contains? old-any uid)
+                                                         (not (contains? new-any uid)))
+                                           :newly-disconnected))))))]
+            newly-disconnected?))
+
+        send-fn ; server>user (by uid) push
+        (fn [user-id ev & [{:as opts :keys [flush?]}]]
+          (let [uid     (if (= user-id :sente/all-users-without-uid) ::nil-uid user-id)
+                _       (tracef "Chsk send: (->uid %s) %s" uid ev)
+                _       (assert uid
+                                (str "Support for sending to `nil` user-ids has been REMOVED. "
+                                     "Please send to `:sente/all-users-without-uid` instead."))
+                _       (assert-event ev)
+                ev-uuid (enc/uuid-str)
+
+                flush-buffer!
+                (fn [type]
+                  (when-let
+                    [pulled
+                     (swap-in! send-buffers_ [type]
+                               (fn [m]
+                                 ;; Don't actually flush unless the event buffered
+                                 ;; with _this_ send call is still buffered (awaiting
+                                 ;; flush). This means that we'll have many (go
+                                 ;; block) buffer flush calls that'll noop. They're
+                                 ;; cheap, and this approach is preferable to
+                                 ;; alternatives like flush workers.
+                                 (let [[_ ev-uuids] (get m uid)]
+                                   (if (contains? ev-uuids ev-uuid)
+                                     (swapped (dissoc m uid)
+                                              (get    m uid))
+                                     (swapped m nil)))))]
+                    (let [[buffered-evs ev-uuids] pulled]
+                      (have? vector? buffered-evs)
+                      (have? set?    ev-uuids)
+
+                      (let [packer-metas         (mapv meta buffered-evs)
+                            combined-packer-meta (reduce merge {} packer-metas)
+                            buffered-evs-ppstr   (pack packer
+                                                       combined-packer-meta
+                                                       buffered-evs)]
+                        (tracef "buffered-evs-ppstr: %s (with meta %s)"
+                                buffered-evs-ppstr combined-packer-meta)
+                        (case type
+                          :ws   (send-buffered-evs>ws-clients!   conns_
+                                                                 uid buffered-evs-ppstr)
+                          :ajax (send-buffered-evs>ajax-clients! conns_
+                                                                 uid buffered-evs-ppstr))))))]
+
+            (if (= ev [:chsk/close]) ; Currently undocumented
+              (do
+                (debugf "Chsk closing (client may reconnect): %s" uid)
+                (when flush?
+                  (doseq [type [:ws :ajax]]
+                    (flush-buffer! type)))
+
+                (doseq [net-ch (vals (get-in @conns_ [:ws uid]))]
+                  (interfaces/close! net-ch))
+
+                (doseq [[?net-ch _] (vals (get-in @conns_ [:ajax uid]))]
+                  (when-let [net-ch ?net-ch]
+                    (interfaces/close! net-ch))))
+
+              (do
+                ;; Buffer event
+                (doseq [type [:ws :ajax]]
+                  (swap-in! send-buffers_ [type uid]
+                            (fn [?v]
+                              (if-not ?v
+                                [[ev] #{ev-uuid}]
+                                (let [[buffered-evs ev-uuids] ?v]
+                                  [(conj buffered-evs ev)
+                                   (conj ev-uuids     ev-uuid)])))))
+
+                ;;; Flush event buffers after relevant timeouts:
+                ;; * May actually flush earlier due to another timeout.
+                ;; * We send to _all_ of a uid's connections.
+                ;; * Broadcasting is possible but I'd suggest doing it rarely, and
+                ;;   only to users we know/expect are actually online.
+                (go (when-not flush? (<! (async/timeout send-buf-ms-ws)))
+                    (flush-buffer! :ws))
+                (go (when-not flush? (<! (async/timeout send-buf-ms-ajax)))
+                    (flush-buffer! :ajax)))))
+
+          ;; Server-side send is async so nothing useful to return (currently
+          ;; undefined):
+          nil)
+
+        ev-msg-const {:ch-recv        ch-recv
+                      :send-fn        send-fn
+                      :connected-uids connected-uids_}]
+
+    {:ch-recv        ch-recv
+     :send-fn        send-fn
+     :connected-uids connected-uids_
+
+     :ajax-post-fn ; Does not participate in `conns_` (has specific req->resp)
+     (fn [ring-req]
+       (interfaces/ring-req->net-ch-resp web-server-adapter ring-req
+                                         {:on-open
+                                          (fn [net-ch]
+                                            (let [params        (get ring-req :params)
+                                                  ppstr         (get params   :ppstr)
+                                                  client-id     (get params   :client-id)
+                                                  [clj has-cb?] (unpack packer ppstr)]
+
+                                              (put-event-msg>ch-recv! ch-recv
+                                                                      (merge ev-msg-const
+                                                                             {;; Note that the client-id is provided here just for the
+                                                                              ;; user's convenience. non-lp-POSTs don't actually need a
+                                                                              ;; client-id for Sente's own implementation:
+                                                                              :client-id client-id #_"unnecessary-for-non-lp-POSTs"
+
+                                                                              :ring-req  ring-req
+                                                                              :event     clj
+                                                                              :uid       (user-id-fn ring-req client-id)
+                                                                              :?reply-fn
+                                                                              (when has-cb?
+                                                                                (fn reply-fn [resp-clj] ; Any clj form
+                                                                                  (tracef "Chsk send (ajax reply): %s" resp-clj)
+                                                                                  ;; true iff apparent success:
+                                                                                  (interfaces/send! net-ch
+                                                                                                    (pack packer (meta resp-clj) resp-clj)
+                                                                                                    :close-after-send)))}))
+
+                                              (when-not has-cb?
+                                                (tracef "Chsk send (ajax reply): dummy-cb-200")
+                                                (interfaces/send! net-ch
+                                                                  (pack packer nil :chsk/dummy-cb-200)
+                                                                  :close-after-send))))}))
+
+     :ajax-get-or-ws-handshake-fn ; Ajax handshake/poll, or WebSocket handshake
+     (fn [ring-req]
+       (let [csrf-token (csrf-token-fn ring-req)
+             params     (get ring-req :params)
+             client-id  (get params   :client-id)
+             uid        (user-id-fn ring-req client-id)
+             websocket? (:websocket? ring-req)
+
+             receive-event-msg! ; Partial
+             (fn [event & [?reply-fn]]
+               (put-event-msg>ch-recv! ch-recv
+                                       (merge ev-msg-const
+                                              {:client-id client-id
+                                               :ring-req  ring-req
+                                               :event     event
+                                               :?reply-fn ?reply-fn
+                                               :uid       uid})))
+
+             handshake!
+             (fn [net-ch]
+               (tracef "Handshake!")
+               (let [?handshake-data (handshake-data-fn ring-req)
+                     handshake-ev
+                     (if-not (nil? ?handshake-data) ; Micro optimization
+                       [:chsk/handshake [uid csrf-token ?handshake-data]]
+                       [:chsk/handshake [uid csrf-token]])]
+                 (interfaces/send! net-ch
+                                   (pack packer nil handshake-ev)
+                                   (not websocket?))))]
+
+         (if (str/blank? client-id)
+           (let [err-msg "Client's Ring request doesn't have a client id. Does your server have the necessary keyword Ring middleware (`wrap-params` & `wrap-keyword-params`)?"]
+             (errorf (str err-msg ": %s") ring-req)
+             (throw (ex-info err-msg {:ring-req ring-req})))
+
+           (interfaces/ring-req->net-ch-resp web-server-adapter ring-req
+                                             {:on-open
+                                              (fn [net-ch]
+                                                (if websocket?
+                                                  (do ; WebSocket handshake
+                                                    (tracef "New WebSocket channel: %s (%s)"
+                                                            uid (str net-ch)) ; _Must_ call `str` on net-ch
+                                                    (reset-in! conns_ [:ws uid client-id] net-ch)
+                                                    (when (connect-uid! :ws uid)
+                                                      (receive-event-msg! [:chsk/uidport-open]))
+                                                    (handshake! net-ch))
+
+                                                  ;; Ajax handshake/poll connection:
+                                                  (let [initial-conn-from-client?
+                                                        (swap-in! conns_ [:ajax uid client-id]
+                                                                  (fn [?v] (swapped [net-ch (enc/now-udt)] (nil? ?v))))
+
+                                                        handshake? (or initial-conn-from-client?
+                                                                       (:handshake? params))]
+
+                                                    (when (connect-uid! :ajax uid)
+                                                      (receive-event-msg! [:chsk/uidport-open]))
+
+                                                    ;; Client will immediately repoll:
+                                                    (when handshake? (handshake! net-ch)))))
+
+                                              :on-msg ; Only for WebSockets
+                                              (fn [net-ch req-ppstr]
+                                                (let [[clj ?cb-uuid] (unpack packer req-ppstr)]
+                                                  (receive-event-msg! clj ; Should be ev
+                                                                      (when ?cb-uuid
+                                                                        (fn reply-fn [resp-clj] ; Any clj form
+                                                                          (tracef "Chsk send (ws reply): %s" resp-clj)
+                                                                          ;; true iff apparent success:
+                                                                          (interfaces/send! net-ch
+                                                                                            (pack packer (meta resp-clj) resp-clj ?cb-uuid)))))))
+
+                                              :on-close ; We rely on `on-close` to trigger for _every_ conn!
+                                              (fn [net-ch status]
+                                                ;; `status` is currently unused; its form varies depending on
+                                                ;; the underlying web server
+
+                                                (if websocket?
+                                                  (do ; WebSocket close
+                                                    (swap-in! conns_ [:ws uid]
+                                                              (fn [?m]
+                                                                (let [new-m (dissoc ?m client-id)]
+                                                                  (if (empty? new-m) :swap/dissoc new-m))))
+
+                                                    ;; (when (upd-connected-uid! uid)
+                                                    ;;   (receive-event-msg! [:chsk/uidport-close]))
+
+                                                    (go
+                                                     ;; Allow some time for possible reconnects (sole window
+                                                     ;; refresh, etc.):
+                                                     (<! (async/timeout 5000))
+
+                                                     ;; Note different (simpler) semantics here than Ajax
+                                                     ;; case since we don't have/want a `udt-disconnected` value.
+                                                     ;; Ajax semantics: 'no reconnect since disconnect+5s'.
+                                                     ;; WS semantics: 'still disconnected after disconnect+5s'.
+                                                     ;;
+                                                     (when (upd-connected-uid! uid)
+                                                       (receive-event-msg! [:chsk/uidport-close]))))
+
+                                                  (do ; Ajax close
+                                                    (swap-in! conns_ [uid :ajax client-id]
+                                                              (fn [[net-ch udt-last-connected]] [nil udt-last-connected]))
+
+                                                    (let [udt-disconnected (enc/now-udt)]
+                                                      (go
+                                                       ;; Allow some time for possible poller reconnects:
+                                                       (<! (async/timeout 5000))
+                                                       (let [disconnected?
+                                                             (swap-in! conns_ [:ajax uid]
+                                                                       (fn [?m]
+                                                                         (let [[_ ?udt-last-connected] (get ?m client-id)
+                                                                               disconnected?
+                                                                               (and ?udt-last-connected ; Not yet gc'd
+                                                                                    (>= udt-disconnected
+                                                                                        ?udt-last-connected))]
+                                                                           (if-not disconnected?
+                                                                             (swapped ?m (not :disconnected))
+                                                                             (let [new-m (dissoc ?m client-id)]
+                                                                               (swapped
+                                                                                (if (empty? new-m) :swap/dissoc new-m)
+                                                                                :disconnected))))))]
+                                                         (when disconnected?
+                                                           (when (upd-connected-uid! uid)
+                                                             (receive-event-msg! [:chsk/uidport-close])))))))))}))))}))
+
+
+(defn- send-buffered-evs>ws-clients!
+  "Actually pushes buffered events (as packed-str) to all uid's WebSocket conns."
+  [conns_ uid buffered-evs-pstr]
+  (tracef "send-buffered-evs>ws-clients!: %s" buffered-evs-pstr)
+  (doseq [net-ch (vals (get-in @conns_ [:ws uid]))]
+    (interfaces/send! net-ch buffered-evs-pstr)))
+
+
+(defn- send-buffered-evs>ajax-clients!
+  "Actually pushes buffered events (as packed-str) to all uid's Ajax conns.
+  Allows some time for possible Ajax poller reconnects."
+  [conns_ uid buffered-evs-pstr & [{:keys [nmax-attempts ms-base ms-rand]
+                                    ;; <= 7 attempts at ~135ms ea = 945ms
+                                    :or   {nmax-attempts 7
+                                           ms-base       90
+                                           ms-rand       90}}]]
+  (comment (* 7 (+ 90 (/ 90 2.0))))
+  (let [;; All connected/possibly-reconnecting client uuids:
+        client-ids-unsatisfied (keys (get-in @conns_ [:ajax uid]))]
+    (when-not (empty? client-ids-unsatisfied)
+      ;; (tracef "client-ids-unsatisfied: %s" client-ids-unsatisfied)
+      (go-loop [n 0 client-ids-satisfied #{}]
+               (let [?pulled ; nil or {<client-id> [<?net-ch> <udt-last-connected>]}
+                     (swap-in! conns_ [:ajax uid]
+                               (fn [m] ; {<client-id> [<?net-ch> <udt-last-connected>]}
+                                 (let [ks-to-pull (remove client-ids-satisfied (keys m))]
+                                   ;; (tracef "ks-to-pull: %s" ks-to-pull)
+                                   (if (empty? ks-to-pull)
+                                     (swapped m nil)
+                                     (swapped
+                                      (reduce
+                                       (fn [m k]
+                                         (let [[?net-ch udt-last-connected] (get m k)]
+                                           (assoc m k [nil udt-last-connected])))
+                                       m ks-to-pull)
+                                      (select-keys m ks-to-pull))))))]
+                 (have? [:or nil? map?] ?pulled)
+                 (let [?newly-satisfied
+                       (when ?pulled
+                         (reduce-kv
+                          (fn [s client-id [?net-ch _]]
+                            (if (or (nil? ?net-ch)
+                                    ;; net-ch may have closed already (`send!` will noop):
+                                    (not (interfaces/send! ?net-ch buffered-evs-pstr
+                                                           :close-after-send)))
+                              s
+                              (conj s client-id))) #{} ?pulled))
+                       now-satisfied (into client-ids-satisfied ?newly-satisfied)]
+                   ;; (tracef "now-satisfied: %s" now-satisfied)
+                   (when (and (< n nmax-attempts)
+                              (some (complement now-satisfied) client-ids-unsatisfied))
+                     ;; Allow some time for possible poller reconnects:
+                     (<! (async/timeout (+ ms-base (rand-int ms-rand))))
+                     (recur (inc n) now-satisfied))))))))
+
+;; ;;;; Client API
+;; ;;;; Router wrapper
+
+(defn start-chsk-router!
+  "Creates a go-loop to call `(event-msg-handler <event-msg>)` and returns a
+  `(fn stop! [])`. Catches & logs errors. Advanced users may choose to instead
+  write their own loop against `ch-recv`."
+  [ch-recv event-msg-handler & [{:as opts :keys [trace-evs? error-handler]}]]
+  (let [ch-ctrl (chan)]
+    (go-loop []
+             (let [[v p] (async/alts! [ch-recv ch-ctrl])
+                   stop? (enc/kw-identical? p  ch-ctrl)]
+
+               (when-not stop?
+                 (let [{:as event-msg :keys [event]} v
+                       [_ ?error]
+                       (enc/catch-errors
+                        (when trace-evs? (tracef "Pre-handler event: %s" event))
+                        (event-msg-handler (have :! event-msg? event-msg)))]
+
+                   (when-let [e ?error]
+                     (let [[_ ?error2]
+                           (enc/catch-errors
+                            (if-let [eh error-handler]
+                              (error-handler e event-msg)
+                              (errorf e "Chsk router `event-msg-handler` error: %s" event)))]
+                       (when-let [e2 ?error2]
+                         (errorf e2 "Chsk router `error-handler` error: %s" event))))
+
+                   (recur)))))
+
+    (fn stop! [] (async/close! ch-ctrl))))
+
+;; ;;;; Deprecated
+
+
+;; (defn start-chsk-router-loop!
+;;   "DEPRECATED: Please use `start-chsk-router!` instead."
+;;   [event-msg-handler ch-recv]
+;;   (start-chsk-router! ch-recv
+;;     ;; Old handler form: (fn [ev-msg ch-recv])
+;;     (fn [ev-msg] (event-msg-handler ev-msg (:ch-recv ev-msg)))))
+
+
+;; (defn set-logging-level! "DEPRECATED. Please use `timbre/set-level!` instead."
+;;   [level] (timbre/set-level! level))


### PR DESCRIPTION
I added a server adapter for Node.js.  In addition to the adapter I added sente-node.cljs.  This is sente.clj adapted to clojurescript on the server.  Ideally this can be merged back into sente.cljx however it will require the renaming of some functions because it breaks the implicit assumption that all cljs is on the client.