### PR TITLE
Immediately reconnect when called on with closed socket.

### DIFF
--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -791,6 +791,7 @@
         (when-let [s @socket_] (.close s 3000 "SENTE_RECONNECT")))
       (do
         (.clearInterval js/window @kalive-timer_)
+        (reset! nattempt_ 0)
         (infof "Forced reconnect attempt.")
         (@connect-fn))))
 


### PR DESCRIPTION
This makes chsk-reconnect!, when called on a closed socket,
attempt to connect immediately. It retains the original behaviour
of incrementing the backoff.

There is one issue with this at present, which is that it can cause
multiple sockets to be opened (if chsk-reconnect! is used repeatedly,
or if the timer fires at exactly the same time, probably.)

Considering adding a mutex "connecting?" to the state atom, but wanted
to check that was sane first.