### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,15 +356,15 @@ Copyright &copy; 2012-2014 Peter Taoussanis. Distributed under the [Eclipse Publ
 
 [example projects]: #example-projects
 [reference example project]: https://github.com/ptaoussanis/sente/tree/master/example-project
-[Go]: http://en.wikipedia.org/wiki/Go_game
+[Go]: https://en.wikipedia.org/wiki/Go_game
 [edn]: https://github.com/edn-format/edn
 [http-kit]: https://github.com/http-kit/http-kit
 [Immutant v2+]: http://immutant.org/
 [nginx-clojure]: https://github.com/nginx-clojure/nginx-clojure
 [Reactjs]: http://facebook.github.io/react/
 [Reagent]: http://reagent-project.github.io/
-[Om]: https://github.com/swannodette/om
-[Chord]: https://github.com/james-henderson/chord
+[Om]: https://github.com/omcljs/om
+[Chord]: https://github.com/jarohen/chord
 [jetty7-websockets-async]: https://github.com/lynaghk/jetty7-websockets-async
 [Socket.IO]: http://socket.io/
 [om-sente]: https://github.com/seancorfield/om-sente


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### Corrected URLs 
Was | Now 
--- | --- 
http://en.wikipedia.org/wiki/Go_game | https://en.wikipedia.org/wiki/Go_game 
https://github.com/swannodette/om | https://github.com/omcljs/om 
https://github.com/james-henderson/chord | https://github.com/jarohen/chord 
