### PR TITLE
Use standard header for CSRF

### DIFF
--- a/example-project/src/example/server.clj
+++ b/example-project/src/example/server.clj
@@ -60,7 +60,8 @@
       {:keys [ch-recv send-fn ajax-post-fn ajax-get-or-ws-handshake-fn
               connected-uids]}
       (sente/make-channel-socket-server! sente-web-server-adapter
-        {:packer packer})]
+        {:packer packer
+         :csrf-path [:headers :X-CSRF-Token]})]
 
   (def ring-ajax-post                ajax-post-fn)
   (def ring-ajax-get-or-ws-handshake ajax-get-or-ws-handshake-fn)
@@ -115,17 +116,12 @@
   (route/not-found "<h1>Page not found</h1>"))
 
 (def main-ring-handler
-  (let [ring-defaults-config
-        (assoc-in ring.middleware.defaults/site-defaults
-          [:security :anti-forgery]
-          {:read-token (fn [req] (-> req :params :csrf-token))})]
-
-    ;; NB: Sente requires the Ring `wrap-params` + `wrap-keyword-params`
-    ;; middleware to work. These are included with
-    ;; `ring.middleware.defaults/wrap-defaults` - but you'll need to ensure
-    ;; that they're included yourself if you're not using `wrap-defaults`.
-    (ring.middleware.defaults/wrap-defaults
-      ring-routes ring-defaults-config)))
+  ;; NB: Sente requires the Ring `wrap-params` + `wrap-keyword-params`
+  ;; middleware to work. These are included with
+  ;; `ring.middleware.defaults/wrap-defaults` - but you'll need to ensure
+  ;; that they're included yourself if you're not using `wrap-defaults`.
+  (ring.middleware.defaults/wrap-defaults
+   ring-routes ring.middleware.defaults/site-defaults))
 
 ;;;; Sente event handlers
 


### PR DESCRIPTION
Use the "X-CSRF-Token" header rather than the "csrf" post paramter.
This makes the CSRF token available to ring.anti-forgery using the
default settings as well as csurf when using express.

ring-anti-forgery:
```clojure
(defn- default-request-token [request]
  (or (-> request form-params (get "__anti-forgery-token"))
      (-> request :headers (get "x-csrf-token"))
      (-> request :headers (get "x-xsrf-token"))))
```
csurf:
```javascript
function defaultValue(req) {
  return (req.body && req.body._csrf)
      || (req.query && req.query._csrf)
      || (req.headers['csrf-token'])
      || (req.headers['xsrf-token'])
      || (req.headers['x-csrf-token'])
      || (req.headers['x-xsrf-token']);
}
```

I should point out this would require a change to the ring.anti-forgery middleware setup to account for this, as well as the login ajax call on clients.