### PR TITLE
Only call get-window-location if location is applicable

### DIFF
--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -1058,7 +1058,7 @@
 
   (let [packer (interfaces/coerce-packer packer)
 
-        win-location (enc/get-window-location)
+        win-location (and (.-location js/window) (enc/get-window-location))
         win-protocol      (:protocol win-location)
         host     (or host (:host     win-location))
         path     (or path (:pathname win-location))


### PR DESCRIPTION
@ptaoussanis for issue https://github.com/ptaoussanis/sente/issues/218

Tested on a react native project by exporting to a local jar, and it worked fine.