### PR TITLE
Little fix to display the message "Channel socket successfully established!"

### DIFF
--- a/example-project/src/example/client.cljs
+++ b/example-project/src/example/client.cljs
@@ -69,7 +69,7 @@
 
 (defmethod -event-msg-handler :chsk/state
   [{:as ev-msg :keys [?data]}]
-  (if (= ?data {:first-open? true})
+  (if (:first-open? ?data)
     (->output! "Channel socket successfully established!")
     (->output! "Channel socket state change: %s" ?data)))
 


### PR DESCRIPTION
The message "Channel socket successfully established!" was never displayed before this fix. After this place I can safely start to communicate over the channel, so it seems to be pretty important point.