### PR TITLE
Clear the keep alive timer in `chsk-disconnect!`

### DIFF
--- a/src/taoensso/sente.cljx
+++ b/src/taoensso/sente.cljx
@@ -776,6 +776,8 @@
   (chsk-destroy!    [chsk] (chsk-disconnect! chsk))
   (chsk-disconnect! [chsk]
     (reset! active-retry-id_ "disconnected")
+    (when @kalive-timer_
+      (.clearInterval js/window @kalive-timer_))
     (merge>chsk-state! chsk {:open? false})
     (when-let [s @socket_] (.close s 1000 "CLOSE_NORMAL")))
 


### PR DESCRIPTION
This prevents multiple timers from piling up.  Not needed in `chsk-reconnect!` as it calls `-chsk-connect!`, which clears it already.