### PR TITLE
Add Aleph adapter

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,8 @@
     {:dependencies
      [[http-kit         "2.2.0-alpha1"]
       [org.immutant/web "2.1.3"]
-      [nginx-clojure    "0.4.4"]]
+      [nginx-clojure    "0.4.4"]
+      [aleph            "0.4.1"]]
      :plugins
      [;;; These must be in :dev, Ref. https://github.com/lynaghk/cljx/issues/47:
       [com.keminglabs/cljx             "0.6.0"]

--- a/src/taoensso/sente/server_adapters/aleph.clj
+++ b/src/taoensso/sente/server_adapters/aleph.clj
@@ -1,0 +1,39 @@
+(ns taoensso.sente.server-adapters.aleph
+  "Sente server adapter for Aleph."
+  {:author "Zach Tellman <@ztellman>, Alex Gunnarson <@alexandergunnarson>"}
+  (:require
+    [taoensso.sente.interfaces :as i   ]
+    [aleph.http                :as http]
+    [manifold.stream           :as s   ]
+    [manifold.deferred         :as d   ]))
+
+(extend-type manifold.stream.core.IEventSink
+  i/IServerChan
+  (sch-open?  [hk-ch] (not (s/closed? hk-ch)))
+  (sch-close! [hk-ch] (s/close! hk-ch))
+  (-sch-send! [hk-ch msg close-after-send?]
+    (s/put! hk-ch msg)
+    (when close-after-send?
+      #_(s/close! hk-ch)))) ; This causes problems because it seems that it wants to close the socket *every* time even with a callback
+
+(defn websocket-request? [req]
+  (= "websocket" (-> req :headers (get "upgrade"))))
+
+(deftype AlephAsyncNetworkChannelAdapter []
+  i/IServerChanAdapter
+  (ring-req->server-ch-resp [this req callbacks]
+    (let [{:keys [on-open on-msg on-close]} callbacks]
+      (if (websocket-request? req)
+          (d/chain (http/websocket-connection req)
+            (fn [s]
+              (when on-open  (on-open s))
+              (when on-msg   (s/consume (fn [result] (on-msg s result)) s))
+              (when on-close (s/on-closed s #(on-close s nil)))
+              {:body s}))
+          (let [s (s/stream)]
+            (when on-open  (on-open s))
+            (when on-close (s/on-closed s #(on-close s nil)))
+            {:body s})))))
+
+(def aleph-adapter (AlephAsyncNetworkChannelAdapter.))
+(def sente-web-server-adapter aleph-adapter) ; Alias for ns import convenience


### PR DESCRIPTION
Continuation of #208 : An adapter for Aleph. Code is heavily borrowed from @ztellman ’s preliminary implementation, but  modified as needed to ensure proper functioning. I’m sure @ztellman can find some holes in it (e.g. with the socket for some reason wanting to close on every message received), but I’ve tested this adapter with the ws and wss sockets I’m using in a remotely deployed test app of mine and it’s been working great so far.