### PR TITLE
working aleph server adapter (i think?)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,8 @@
     {:dependencies
      [[http-kit         "2.2.0-alpha2"]
       [org.immutant/web "2.1.4"]
-      [nginx-clojure    "0.4.4"]]
+      [nginx-clojure    "0.4.4"]
+      [aleph "0.4.1"]]
      :plugins
      [;;; These must be in :dev, Ref. https://github.com/lynaghk/cljx/issues/47:
       [com.keminglabs/cljx             "0.6.0"]

--- a/src/taoensso/sente/server_adapters/aleph.clj
+++ b/src/taoensso/sente/server_adapters/aleph.clj
@@ -1,0 +1,37 @@
+(ns taoensso.sente.server-adapters.aleph
+  (:require
+    [taoensso.sente.interfaces :as i]
+    [aleph.http :as http]
+    [manifold.stream :as s]
+    [manifold.deferred :as d]))
+
+(extend-type manifold.stream.core.IEventSink
+  i/IServerChan
+  (sch-open? [s] (not (s/closed? s)))
+  (sch-close! [s] (s/close! s))
+  (-sch-send! [s msg close-after-send?]
+    (s/put! s msg)
+    (when close-after-send?
+      (s/close! s))))
+
+(defn websocket-request? [req]
+  (= "websocket" (-> req :headers (get "upgrade"))))
+
+(deftype AlephAsyncNetworkChannelAdapter []
+  i/IServerChanAdapter
+  (ring-req->server-ch-resp [server-ch-adapter ring-req callbacks-map]
+    (let [{:keys [on-open on-msg on-close]} callbacks-map]
+      (if (websocket-request? ring-req)
+        (d/chain (http/websocket-connection ring-req)
+          (fn [s]
+            (when on-open (on-open s))
+            (when on-msg (s/consume on-msg s))
+            (when on-close (s/on-closed s #(on-close s nil)))
+            {:body s}))
+        (let [s (s/stream)]
+          (when on-open (on-open s))
+          (when on-close (s/on-closed s #(on-close s nil)))
+          {:body s})))))
+
+(def aleph-adapter (AlephAsyncNetworkChannelAdapter.))
+(def sente-web-server-adapter aleph-adapter) ; Alias for ns import convenience


### PR DESCRIPTION
Hello,

As far as I can tell this works, provided that when you create your Ring middleware, you ensure that you add the `{:websocket? true}` key to the request when appropriate. I'm not sure if this is acceptable, or if I can do it directly in the server adapter, so some guidance here would be helpful.

I've test that websocket clients work under the conditions mentioned above. I haven't directly tested that ajax polling works though. 