### PR TITLE
Warn about lost handle when we expected to have a handle

### DIFF
--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -983,7 +983,9 @@
                connect-fn
                (fn connect-fn []
                  (if-not (have-handle?)
-                   (warnf "Aborting reconnect attempt (lost handle)")
+                   (let [close-reason (get-in @state_ [:last-close :reason])]
+                     (when (or (nil? close-reason) (= :unexpected close-reason))
+                       (warnf "Aborting reconnect attempt (lost handle)")))
                    (let [retry-fn
                          (fn [] ; Backoff then recur
                            (when (have-handle?)


### PR DESCRIPTION
If we intentionally disconnect a Sente chsk, previously we would have
gotten a warning "Aborting reconnect attempt (lost handle)" when the
retry handler ran. After this commit, this warning only shows when we
expect we should have a retry handle.