### PR TITLE
Add :next-reconnect key to chsk state

### DIFF
--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -42,20 +42,20 @@
         [:chsk/ws-ping]
 
   Channel socket state map:
-    :type           - e/o #{:auto :ws :ajax}
-    :open?          - Truthy iff chsk appears to be open (connected) now
-    :ever-opened?   - Truthy iff chsk handshake has ever completed successfully
-    :first-open?    - Truthy iff chsk just completed first successful handshake
-    :uid            - User id provided by server on handshake,    or nil
-    :csrf-token     - CSRF token provided by server on handshake, or nil
-    :handshake-data - Arb user data provided by server on handshake
-    :last-ws-error  - ?{:udt _ :ev <WebSocket-on-error-event>}
-    :last-ws-close  - ?{:udt _ :ev <WebSocket-on-close-event>
-                        :clean? _ :code _ :reason _}
-    :last-close     - ?{:udt _ :reason _}, with reason e/o
-                        #{nil :requested-disconnect :requested-reconnect
-                         :downgrading-ws-to-ajax :unexpected}
-    :next-reconnect - ?udt of next reconnect attempt
+    :type               - e/o #{:auto :ws :ajax}
+    :open?              - Truthy iff chsk appears to be open (connected) now
+    :ever-opened?       - Truthy iff chsk handshake has ever completed successfully
+    :first-open?        - Truthy iff chsk just completed first successful handshake
+    :uid                - User id provided by server on handshake,    or nil
+    :csrf-token         - CSRF token provided by server on handshake, or nil
+    :handshake-data     - Arb user data provided by server on handshake
+    :last-ws-error      - ?{:udt _ :ev <WebSocket-on-error-event>}
+    :last-ws-close      - ?{:udt _ :ev <WebSocket-on-close-event>
+                            :clean? _ :code _ :reason _}
+    :last-close         - ?{:udt _ :reason _}, with reason e/o
+                            #{nil :requested-disconnect :requested-reconnect
+                             :downgrading-ws-to-ajax :unexpected}
+    :udt-next-reconnect - Approximate udt of next scheduled auto-reconnect attempt
 
   Notable implementation details:
     * core.async is used liberally where brute-force core.async allows for
@@ -829,12 +829,12 @@
                    :requested-reconnect
                    :downgrading-ws-to-ajax
                    :unexpected}] reason)
-     (let [state (dissoc state :next-reconnect)]
-       (if (or (:open? state) (not= reason :unexpected))
-         (assoc state
-           :open? false
-           :last-close {:udt (enc/now-udt) :reason reason})
-         state))))
+     (if (or (:open? state) (not= reason :unexpected))
+       (-> state
+           (dissoc :next-reconnect)
+           (assoc :open? false
+                  :last-close {:udt (enc/now-udt) :reason reason}))
+       state)))
 
 #?(:cljs
    (defn- cb-chan-as-fn
@@ -1050,7 +1050,8 @@
                                      (receive-handshake! :ws chsk clj)
                                      (reset! retry-count_ 0)
                                      (swap-chsk-state! chsk
-                                       #(dissoc % :next-reconnect)))
+                                       #(dissoc % :next-reconnect))
+                                     true)
 
                                    (when (= clj :chsk/ws-ping)
                                      (put! (:<server chs) [:chsk/ws-ping])

--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -1497,8 +1497,13 @@
 
 (defn- -start-chsk-router!
   [server? ch-recv event-msg-handler opts]
-  (let [{:keys [trace-evs? error-handler]} opts
-        ch-ctrl (chan)]
+  (let [{:keys [trace-evs? error-handler simple-auto-threading?]} opts
+        ch-ctrl (chan)
+
+        execute1
+        (if #?(:clj simple-auto-threading? :cljs false)
+          (fn [f] (future-call f))
+          (fn [f] (f)))]
 
     (go-loop []
       (let [[v p] (async/alts! [ch-recv ch-ctrl])
@@ -1507,19 +1512,21 @@
         (when-not stop?
           (let [{:as event-msg :keys [event]} v]
 
-            (enc/catching
-              (do
-                (when trace-evs? (tracef "Pre-handler event: %s" event))
-                (event-msg-handler
-                  (if server?
-                    (have! server-event-msg? event-msg)
-                    (have! client-event-msg? event-msg))))
-              e1
-              (enc/catching
-                (if-let [eh error-handler]
-                  (error-handler e1 event-msg)
-                  (errorf e1 "Chsk router `event-msg-handler` error: %s" event))
-                e2 (errorf e2 "Chsk router `error-handler` error: %s" event)))
+            (execute1
+              (fn []
+                (enc/catching
+                  (do
+                    (when trace-evs? (tracef "Pre-handler event: %s" event))
+                    (event-msg-handler
+                      (if server?
+                        (have! server-event-msg? event-msg)
+                        (have! client-event-msg? event-msg))))
+                  e1
+                  (enc/catching
+                    (if-let [eh error-handler]
+                      (error-handler e1 event-msg)
+                       (errorf e1 "Chsk router `event-msg-handler` error: %s" event))
+                    e2 (errorf e2 "Chsk router `error-handler` error: %s"     event)))))
 
             (recur)))))
 
@@ -1527,40 +1534,33 @@
 
 (defn start-server-chsk-router!
   "Creates a simple go-loop to call `(event-msg-handler <server-event-msg>)`
-  and log any errors. Returns a `(fn stop! [])`.
+  and log any errors. Returns a `(fn stop! [])`. Note that advanced users may
+  prefer to just write their own loop against `ch-recv`.
 
   Nb performance note: since your `event-msg-handler` fn will be executed
   within a simple go block, you'll want this fn to be ~non-blocking
   (you'll especially want to avoid blocking IO) to avoid starving the
-  core.async thread pool under load.
+  core.async thread pool under load. To avoid blocking, you can use futures,
+  agents, core.async, etc. as appropriate.
 
-  To avoid blocking, Clojure offers a rich variety of tools incl. futures,
-  agents, core.async, etc. The correct tool/s to use will depend on your
-  application (and on the particular request/s), so this isn't something the
-  router can/should handle for you automatically.
-
-  Note that advanced users may also prefer to just write their own loop
-  against `ch-recv`."
-  [ch-recv event-msg-handler & [{:as opts :keys [trace-evs? error-handler]}]]
+  Or for simple automatic future-based threading of every request, enable
+  the `:simple-auto-threading?` opt (disabled by default)."
+  [ch-recv event-msg-handler &
+   [{:as opts :keys [trace-evs? error-handler simple-auto-threading?]}]]
   (-start-chsk-router! :server ch-recv event-msg-handler opts))
 
 (defn start-client-chsk-router!
   "Creates a simple go-loop to call `(event-msg-handler <server-event-msg>)`
-  and log any errors. Returns a `(fn stop! [])`.
+  and log any errors. Returns a `(fn stop! [])`. Note that advanced users may
+  prefer to just write their own loop against `ch-recv`.
 
   Nb performance note: since your `event-msg-handler` fn will be executed
   within a simple go block, you'll want this fn to be ~non-blocking
   (you'll especially want to avoid blocking IO) to avoid starving the
-  core.async thread pool under load.
-
-  To avoid blocking, Clojure offers a rich variety of tools incl. futures,
-  agents, core.async, etc. The correct tool/s to use will depend on your
-  application (and on the particular request/s), so this isn't something the
-  router can/should handle for you automatically.
-
-  Note that advanced users may also prefer to just write their own loop
-  against `ch-recv`."
-  [ch-recv event-msg-handler & [{:as opts :keys [trace-evs? error-handler]}]]
+  core.async thread pool under load. To avoid blocking, you can use futures,
+  agents, core.async, etc. as appropriate."
+  [ch-recv event-msg-handler &
+   [{:as opts :keys [trace-evs? error-handler]}]]
   (-start-chsk-router! (not :server) ch-recv event-msg-handler opts))
 
 ;;;; Platform aliases


### PR DESCRIPTION
It is often desirable to know when the chsk will next attempt to reconnect, to show the user some UI for this. This patch adds a key :next-reconnect which adds the udt of the next reconnect time to the
state map when the chsk is offline, and removes it when it is online, or stopped.