### PR TITLE
add clj client support

### DIFF
--- a/src/taoensso/sente/client_adapters/aleph.clj
+++ b/src/taoensso/sente/client_adapters/aleph.clj
@@ -1,0 +1,35 @@
+(ns taoensso.sente.client-adapters.aleph
+  "Sente client adapter for Aleph (https://github.com/ztellman/aleph)."
+  {:author "Frozenlock"}
+  (:require
+   [taoensso.sente.interfaces :as i]  
+   [aleph.http        :as aleph]
+   [manifold.stream   :as s]
+   [taoensso.timbre :as timbre :refer (tracef debugf infof warnf errorf)]))
+
+
+(extend-type manifold.stream.core.IEventSink
+  i/IClientWebSocket
+  (cws-close! [cws]       
+    (s/close! cws))
+  (cws-send!  [cws msg]
+    (if (s/closed? cws)
+      false
+      (do (s/put! cws msg)
+          true))))
+
+(defn aleph-create-client-websocket! 
+  "Create a websocket with provided URL. Return an IClientWebSocket
+  implementation, or nil if connection failed."
+  [url {:keys [on-msg on-error on-close]}]
+  (let [ws (try @(aleph/websocket-client url)
+                (catch Exception e 
+                  (do (errorf e)
+                      nil)))]
+    (when ws
+      (when on-msg (s/consume (fn [msg] 
+                                (try (on-msg msg)
+                                     (catch Exception e
+                                       (when on-error e)))) ws))
+      (when on-close (s/on-closed ws (fn [] (on-close [:aleph/closed]))))
+      ws)))

--- a/src/taoensso/sente/interfaces.cljc
+++ b/src/taoensso/sente/interfaces.cljc
@@ -46,3 +46,28 @@
   arbitrary Clojure data <-> serialized strings."
   (pack   [_ x])
   (unpack [_ x]))
+
+
+;;;; Client sockets
+
+(defprotocol IClientWebSocket ; cws
+  ;; Wraps a client's socket interface to abstract away
+  ;; implementation differences.
+  
+  (cws-close! [cws] "If the channel is open when called: closes the channel and returns true.
+    Otherwise noops and returns false.")
+  (cws-send! [cws msg]
+   "If the socket is open when called: sends a message over socket and
+    returns true. Otherwise noops and returns false."))
+
+
+;; Client websocket creator can be provided in the field :cws-creator.
+;; The result should implement IClientWebsocket.
+;; Here are the arguments the creator should expect :
+;; [url callbacks-map]
+;; Where `callbacks-map` has the following entry:
+;;      on-msg    - [msg] the message (ppstr)
+;;      on-error  - [evt]
+;;      on-close  - [evt]
+;; The websocket creator should return nil if it can't connect.
+


### PR DESCRIPTION
I tried to separate `sente`'s logic from the websocket implementation while changing the least amount of things possible. Ajax is still cljs only.

It's probably a little more low-level than the `IServerChanAdapter`. Here we provide a function to let `sente` create new websockets when needed.

Tested with both cljs and clj (aleph) and it seems to work.
