### PR TITLE
Bump core.async and aleph versions for new specs in clojure 1.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 
   :dependencies
   [[org.clojure/clojure      "1.7.0"]
-   [org.clojure/core.async   "0.2.395"]
+   [org.clojure/core.async   "0.3.442"]
    [com.taoensso/encore      "2.84.2"]
    [org.clojure/tools.reader "0.10.0"]
    [com.taoensso/timbre      "4.7.4"]]
@@ -40,7 +40,7 @@
      [[http-kit         "2.2.0"]
       [org.immutant/web "2.1.5"]
       [nginx-clojure    "0.4.4"]
-      [aleph            "0.4.1"]]}]}
+      [aleph            "0.4.3"]]}]}
 
   :cljsbuild
   {:test-commands {"node"    ["node" :node-runner "target/main.js"]


### PR DESCRIPTION
Sente does not work with the new specs since it uses an old version of core.async which has a bad :refer-clojure. Fixed in [this commit.](https://github.com/clojure/core.async/commit/2f87bc7c7d10cb7b0baafc86e08489d58fa87424)

Aleph version 0.4.1 has a malformed defn so I bumped that to 0.4.3 as well.

See CLJ-2062 for details.