### PR TITLE
Fix ajax downgrade logic

### DIFF
--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -1344,7 +1344,7 @@
                      (when-let [impl @impl_]
                        (when-let [ever-opened?_ (:ever-opened?_ impl)]
                          (when-not @ever-opened?_
-                           (when (:last-error new-state)
+                           (when (:last-ws-error new-state)
                              (when (compare-and-set! downgraded?_ false true)
                                (warnf "Permanently downgrading :auto chsk -> :ajax")
                                (-chsk-disconnect! impl :downgrading-ws-to-ajax)


### PR DESCRIPTION
Re: https://github.com/ptaoussanis/sente/issues/326, I made this change locally and it falls back to the ajax connection upon the initial websocket failure. It seems like the code should be looking `:last-ws-error` used elsewhere in code instead of `:last-error` which does not appear to be used.