### PR TITLE
Fix incorrect value (only udt) swapped into conns_

### DIFF
--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -700,7 +700,7 @@
                                 (fn [[_sch udt-t1]]
                                   (if (= udt-t1 udt-close)
                                     (swapped :swap/dissoc true)
-                                    (swapped udt-t1       false))))]
+                                    (swapped [_sch udt-t1] false))))]
 
                           (when disconnect?
 


### PR DESCRIPTION
The value stored per client session is

  `[server-channel-socket, timestamp]`

but in this particular instance only the timestamp was swapped in.