### PR TITLE
Make cljsbuild output-to resources/public/main.js directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ pom.xml*
 .nrepl-port
 *.jar
 *.class
+*.js
 .env
 .DS_Store
 /lib/

--- a/example-project/project.clj
+++ b/example-project/project.clj
@@ -49,11 +49,13 @@
   {:builds
    [{:id :cljs-client
      :source-paths ["src"]
-     :compiler {:output-to "target/main.js"
+     :compiler {:output-to "resources/public/main.js"
                 :optimizations :whitespace #_:advanced
                 :pretty-print true}}]}
 
   :main example.server
+
+  :clean-targets ^{:protect false} ["resources/public/main.js"]
 
   ;; Call `lein start-repl` to get a (headless) development repl that you can
   ;; connect to with Cider+emacs or your IDE of choice:

--- a/example-project/resources/public/main.js
+++ b/example-project/resources/public/main.js
@@ -1,1 +1,0 @@
-../../target/main.js


### PR DESCRIPTION
Before this change, the example-project couldn't run on Windows-based machines. This change makes it possible to run on any.