### PR TITLE
Revert host overriding functionality

### DIFF
--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -1501,9 +1501,8 @@
                 (f path win-loc :ajax)]
 
                (let [protocol (or protocol (:protocol win-loc) :http)
-                     host     (if port
-                                (str (:hostname win-loc) ":" port)
-                                (or host (:host win-loc)))]
+                     host     (cond-> (or host (:host win-loc))
+                                port (str/replace-first #"(:\d+)?$" (str ":" port)))]
                  [(get-chsk-url protocol host path :ws)
                   (get-chsk-url protocol host path :ajax)])))
 

--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -1503,7 +1503,7 @@
                (let [protocol (or protocol (:protocol win-loc) :http)
                      host     (if port
                                 (str (:hostname win-loc) ":" port)
-                                (do  (:host     win-loc)))]
+                                (or host (:host win-loc)))]
                  [(get-chsk-url protocol host path :ws)
                   (get-chsk-url protocol host path :ajax)])))
 


### PR DESCRIPTION
A previous PR broke the host overriding functionality. This commit fixes it.