### PR TITLE
Allow user to set a host different from the window location

### DIFF
--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -1502,8 +1502,8 @@
 
                (let [protocol (or protocol (:protocol win-loc) :http)
                      host     (if port
-                                (str (:hostname win-loc) ":" port)
-                                (do  (:host     win-loc)))]
+                                (str (or host (:hostname win-loc)) ":" port)
+                                (do (or host (:host win-loc))))]
                  [(get-chsk-url protocol host path :ws)
                   (get-chsk-url protocol host path :ajax)])))
 


### PR DESCRIPTION
I tried to use a custom host from an electron app and notice that the host was always going blank. Looking at the code, the `host` param was being shadowed by the internal `host` on the let. This change fixes it so it first tries to use the user-defined `host` instead of reading from the window location.