### PR TITLE
Support making a sente websocket client connection from clj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ pom.xml*
 /logs/
 /docs/
 /doc/
+/sente.iml
+/.idea/

--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,7 @@
   [[org.clojure/clojure      "1.10.1" :scope "provided"]
    [org.clojure/core.async   "1.2.603"]
    [com.taoensso/encore      "2.122.0"]
+   [org.java-websocket/Java-WebSocket "1.4.0"]
    [org.clojure/tools.reader "1.3.2"]
    [com.taoensso/timbre      "4.10.0"]]
 


### PR DESCRIPTION
- add dependency to pure java ws implementation org.java-websocket/Java-WebSocket
- make chsk-**connect! functions available to clj
- allow setting custom headers to the (java) webclient
- add an "Authorization" header based authorization mechanism for incoming get-or-ws request
- ignore csrf and origin checks if Authorization header exists
- pass uid to authorized-header-fn
- use CloseFrame.normal to test if java ws close was clean
- Make send-buffers public similar to connected-uids