### PR TITLE
Add Jetty adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
  * Standard **Ring security model**: auth as you like, HTTPS when available, CSRF support, etc.
  * **Fully documented, with examples**
  * **Small codebase**: ~1.5k lines for the entire client+server implementation
- * **Supported servers**: [http-kit], [Immutant v2+], [nginx-clojure], node.js, [Aleph]
+ * **Supported servers**: [http-kit], [Immutant v2+], [nginx-clojure], node.js, [Aleph], [ring-jetty9-adapter]
 
 ### Capabilities
 
@@ -422,6 +422,7 @@ Copyright &copy; 2014-2016 [Peter Taoussanis].
 [nginx-clojure]: https://github.com/nginx-clojure/nginx-clojure
 [Aleph]: https://github.com/ztellman/aleph
 [example projects]: #example-projects
+[ring-jetty9-adapter]: https://github.com/sunng87/ring-jetty9-adapter
 
 [supported web servers]: https://github.com/ptaoussanis/sente/issues/102
 

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
       [aleph            "0.4.6"]
       [macchiato/core   "0.2.19"]
       [luminus/ring-undertow-adapter "1.1.1"]
-      [wavejumper/ring-jetty9-adapter "0.13.1-patch6"]]}]}
+      [info.sunng/ring-jetty9-adapter "0.13.0"]]}]}
 
   :cljsbuild
   {:test-commands {"node"    ["node" :node-runner "target/main.js"]

--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,8 @@
       [nginx-clojure    "0.5.1"]
       [aleph            "0.4.6"]
       [macchiato/core   "0.2.19"]
-      [luminus/ring-undertow-adapter "1.1.1"]]}]}
+      [luminus/ring-undertow-adapter "1.1.1"]
+      [wavejumper/ring-jetty9-adapter "0.13.1-patch6"]]}]}
 
   :cljsbuild
   {:test-commands {"node"    ["node" :node-runner "target/main.js"]

--- a/src/taoensso/sente/server_adapters/jetty.clj
+++ b/src/taoensso/sente/server_adapters/jetty.clj
@@ -1,0 +1,60 @@
+(ns taoensso.sente.server-adapters.jetty
+  "Sente adapter for ring-jetty9-adapter (https://github.com/sunng87/ring-jetty9-adapter)
+
+  Note: ring-jetty9-adapter requires its own middleware stack for websocket connections.
+
+  Thus, stateful Ring middleware require a little extra configuration:
+
+  * ring-session: pass shared instance of :store
+  * ring-anti-forgery: pass shared instance of :strategy"
+  {:author "Thomas Crowley (@wavejumper)"}
+  (:require [clojure.string :as str]
+            [ring.adapter.jetty9.websocket :as jetty9.websocket]
+            [taoensso.sente.interfaces :as i])
+  (:import (org.eclipse.jetty.websocket.api WebSocketAdapter)))
+
+(defn ajax-cbs [ws]
+  {:write-failed  (fn [_] (jetty9.websocket/close! ws))
+   :write-success (fn [_] (jetty9.websocket/close! ws))})
+
+(extend-protocol i/IServerChan
+  WebSocketAdapter
+  (sch-open? [ws]
+    (jetty9.websocket/connected? ws))
+
+  (sch-close! [ws]
+    (jetty9.websocket/close! ws))
+
+  (sch-send! [ws ws? msg]
+    (if ws?
+      (jetty9.websocket/send! ws msg)
+      (jetty9.websocket/send! ws msg (ajax-cbs ws)))))
+
+(defrecord JettyServerChanResponse [ws]
+  jetty9.websocket/IWebSocketAdapter
+  (ws-adapter [_] ws))
+
+(defn server-ch-resp
+  [ws? {:keys [on-open on-close on-msg on-error]}]
+  (let [ws (jetty9.websocket/proxy-ws-adapter
+            {:on-connect (fn [ws]
+                           (on-open ws ws?))
+             :on-text    (fn [ws msg]
+                           (on-msg ws ws? msg))
+             :on-close   (fn [ws status-code _]
+                           (on-close ws ws? status-code))
+             :on-error   (fn [ws e]
+                           (on-error ws ws? e))})]
+    (JettyServerChanResponse. ws)))
+
+(defn- websocket-req? [ring-req]
+  (when-let [s (get-in ring-req [:headers "upgrade"])]
+    (= "websocket" (str/lower-case s))))
+
+(deftype JettyServerChanAdapter []
+  i/IServerChanAdapter
+  (ring-req->server-ch-resp [_ req callbacks-map]
+    (server-ch-resp (websocket-req? req) callbacks-map)))
+
+(defn get-sch-adapter []
+  (JettyServerChanAdapter.))

--- a/src/taoensso/sente/server_adapters/jetty.clj
+++ b/src/taoensso/sente/server_adapters/jetty.clj
@@ -30,22 +30,16 @@
       (jetty9.websocket/send! ws msg)
       (jetty9.websocket/send! ws msg (ajax-cbs ws)))))
 
-(defrecord JettyServerChanResponse [ws]
-  jetty9.websocket/IWebSocketAdapter
-  (ws-adapter [_] ws))
-
 (defn server-ch-resp
   [ws? {:keys [on-open on-close on-msg on-error]}]
-  (let [ws (jetty9.websocket/proxy-ws-adapter
-            {:on-connect (fn [ws]
-                           (on-open ws ws?))
-             :on-text    (fn [ws msg]
-                           (on-msg ws ws? msg))
-             :on-close   (fn [ws status-code _]
-                           (on-close ws ws? status-code))
-             :on-error   (fn [ws e]
-                           (on-error ws ws? e))})]
-    (JettyServerChanResponse. ws)))
+  {:on-connect (fn [ws]
+                 (on-open ws ws?))
+   :on-text    (fn [ws msg]
+                 (on-msg ws ws? msg))
+   :on-close   (fn [ws status-code _]
+                 (on-close ws ws? status-code))
+   :on-error   (fn [ws e]
+                 (on-error ws ws? e))})
 
 (defn- websocket-req? [ring-req]
   (when-let [s (get-in ring-req [:headers "upgrade"])]

--- a/src/taoensso/sente/server_adapters/jetty.clj
+++ b/src/taoensso/sente/server_adapters/jetty.clj
@@ -5,8 +5,7 @@
 
   Thus, stateful Ring middleware require a little extra configuration:
 
-  * ring-session: pass shared instance of :store
-  * ring-anti-forgery: pass shared instance of :strategy"
+  * ring-session: pass shared instance of :store"
   {:author "Thomas Crowley (@wavejumper)"}
   (:require [clojure.string :as str]
             [ring.adapter.jetty9.websocket :as jetty9.websocket]

--- a/src/taoensso/sente/server_adapters/jetty.clj
+++ b/src/taoensso/sente/server_adapters/jetty.clj
@@ -15,7 +15,7 @@
 
 (defn ajax-cbs [ws]
   {:write-failed  (fn [_] (jetty9.websocket/close! ws))
-   :write-success (fn [_] (jetty9.websocket/close! ws))})
+   :write-success (fn [] (jetty9.websocket/close! ws))})
 
 (extend-protocol i/IServerChan
   WebSocketAdapter


### PR DESCRIPTION
While the official Jetty adapter for Ring does not support websockets, [ring-jetty9-adapter](https://github.com/sunng87/ring-jetty9-adapter) does - which makes this adapter possible.

Fixes #371

I left some notes in the ns docstring, but here's an example  using [ring-defaults](https://github.com/ring-clojure/ring-defaults):

```clojure
(require '[taoensso.sente :as sente])
(require '[taoensso.sente.server-adapters.jetty :as adapters.jetty])
(require '[ring.middleware.defaults :as ring.defaults])
(require '[ring.adapter.jetty9 :as jetty])

(def sente 
  (sente/make-channel-socket! (adapters.jetty/get-sch-adapter) {}))

(def defaults
  (-> ring.defaults/site-defaults
      (assoc-in [:responses :content-types] false)
      (assoc-in [:session :flash] false)))

(jetty/run-jetty handler {:port 3000
                          :websockets {"/chsk" (-> (:ajax-get-or-ws-handshake-fn sente)
                                                   (ring.defaults/wrap-defaults defaults))}
                          :allow-null-path-info true})
```

`:ajax-post-fn` would be configured as a regular route inside of `handler`