### PR TITLE
Binary data support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,7 @@
+{:deps
+ {org.clojure/core.async   {:mvn/version "1.3.610"}
+  com.taoensso/encore      {:mvn/version "3.12.1"}
+  org.java-websocket/Java-WebSocket {:mvn/version "1.5.1"}
+  org.clojure/tools.reader {:mvn/version "1.3.5"}
+  com.taoensso/timbre      {:mvn/version "5.1.2"}}
+ }


### PR DESCRIPTION
With these modifications I was able to implement a msgpack packer in both Clojure and Clojurescript, so we are now transmitting large binary typed arrays over the websocket channel.  I'm also working on unifying clojure-msgpack and msgpack-cljs libs, and once that work is done I'm happy to also provide the packers so future Sente users can have plug and play binary data support.  Since often times people want to use websockets for dashboards which can often be data heavy, I think this will be a welcome addition.  Please let me know if you have any thoughts or feedback, and I'm happy to work with you on these changes if you have other ideas.  Thanks for Sente!