### PR TITLE
Start ws-kalive loop after connection is established

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ pom.xml*
 *.js
 .env
 .DS_Store
+*.iml
+.idea/
 /lib/
 /classes/
 /target/

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
    :1.9      {:dependencies [[org.clojure/clojure "1.9.0"]]}
    :1.10     {:dependencies [[org.clojure/clojure "1.10.2"]]}
 ;; :depr     {:jvm-opts ["-Dtaoensso.elide-deprecated=true"]}
-   :dev      [:1.10 :test :server-jvm :depr]
+   :dev      [:1.10 :test :server-jvm]
    :test     {:dependencies
               [[com.cognitect/transit-clj  "1.0.324"]
                [com.cognitect/transit-cljs "0.8.264"]

--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -1290,6 +1290,8 @@
 
                     (reset! socket_ ?socket))))))]
 
+      (reset! retry-count_ 0)
+      (connect-fn)
       (when-let [ms ws-kalive-ms]
         (go-loop []
           (let [udt-t0 @udt-last-comms_]
@@ -1307,9 +1309,6 @@
 
                   (-chsk-send! chsk [:chsk/ws-ping] {:flush? true})))
               (recur)))))
-
-      (reset! retry-count_ 0)
-      (connect-fn)
       chsk)))
 
 (defn- new-ChWebSocket [opts csrf-token]


### PR DESCRIPTION
Now the :chsk/ws-ping go-loop starts before `(connect-fn)` is called.
If a connection in `(connect-fn)` can't be established right away, it will enter
`(retry-fn)` loop, until WS conn socket is established. Maybe it takes
forever, maybe it takes just 10 seconds for the remote end to come
online.

Meanwhile, we are sending ourselves the pings in ws-kalive-ms intervals.
Basically means log gets polluted with both:
"Chsk send against closed chsk." from the ws-ping send, and
"Chsk is closed: will try reconnect" from the connection `retry-fn`.

This change will start the go-loop only after we have returned from
`(connect-fn)`.