### PR TITLE
fixing a bug in arraybuffer binary data unwrapped v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@
 
 > **Sen-te** (先手) is a Japanese [Go] term used to describe a play with such an overwhelming follow-up that it demands an immediate response, leaving its player with the initiative.
 
-(I'd also recommend checking out James Henderson's [Chord] and Kevin Lynagh's [jetty7-websockets-async] as possible alternatives!)
-
 ## Features
  * **Bidirectional a/sync comms** over both **WebSockets** and **Ajax** (auto-fallback)
  * **It just works**: auto keep-alives, buffering, protocol selection, reconnects

--- a/example-project/project.clj
+++ b/example-project/project.clj
@@ -11,12 +11,12 @@
 
   :dependencies
   [[org.clojure/clojure       "1.11.1"]
-   [org.clojure/clojurescript "1.11.57"]
-   [org.clojure/core.async    "1.5.648"]
-   [org.clojure/tools.nrepl   "0.2.13"] ; Optional, for Cider
+   [org.clojure/clojurescript "1.11.60"]
+   [org.clojure/core.async    "1.6.673"]
+   [nrepl                     "1.0.0"] ; Optional, for Cider
 
    [com.taoensso/sente        "1.17.0"] ; <--- Sente
-   [com.taoensso/timbre       "5.2.1"]
+   [com.taoensso/timbre       "6.1.0"]
 
    ;;; TODO Choose (uncomment) a supported web server -----------------------
    [http-kit                             "2.6.0"] ; Default
@@ -27,8 +27,8 @@
    ;; [info.sunng/ring-jetty9-adapter    "0.14.2"]
    ;; -----------------------------------------------------------------------
 
-   [ring                      "1.9.5"]
-   [ring/ring-defaults        "0.3.3"] ; Includes `ring-anti-forgery`, etc.
+   [ring                      "1.9.6"]
+   [ring/ring-defaults        "0.3.4"] ; Includes `ring-anti-forgery`, etc.
    ;; [ring-anti-forgery      "1.3.0"]
 
    [compojure                 "1.7.0"] ; Or routing lib of your choice
@@ -37,14 +37,13 @@
    ;;; Transit deps optional; may be used to aid perf. of larger data payloads
    ;;; (see reference example for details):
    [com.cognitect/transit-clj  "1.0.329"]
-   [com.cognitect/transit-cljs "0.8.269"]]
+   [com.cognitect/transit-cljs "0.8.280"]]
 
   :plugins
-  [[lein-pprint         "1.3.2"]
-   [lein-ancient        "0.7.0"]
-   ;[com.cemerick/austin "0.1.6"]
-   [lein-cljsbuild      "1.1.8"]
-   [cider/cider-nrepl   "0.28.4"]] ; Optional, for use with Emacs
+  [[lein-pprint       "1.3.2"]
+   [lein-ancient      "0.7.0"]
+   [lein-cljsbuild    "1.1.8"]
+   [cider/cider-nrepl "0.30.0"]] ; Optional, for use with Emacs
 
   :cljsbuild
   {:builds

--- a/example-project/project.clj
+++ b/example-project/project.clj
@@ -1,4 +1,4 @@
-(defproject com.taoensso.examples/sente "1.17.0"
+(defproject com.taoensso.examples/sente "1.18.0-SNAPSHOT"
   :description "Sente, reference web-app example project"
   :url "https://github.com/ptaoussanis/sente"
   :license {:name "Eclipse Public License"
@@ -15,7 +15,7 @@
    [org.clojure/core.async    "1.6.673"]
    [nrepl                     "1.0.0"] ; Optional, for Cider
 
-   [com.taoensso/sente        "1.17.0"] ; <--- Sente
+   [com.taoensso/sente        "1.18.0-SNAPSHOT"] ; <--- Sente
    [com.taoensso/timbre       "6.1.0"]
 
    ;;; TODO Choose (uncomment) a supported web server -----------------------

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.taoensso/sente "1.17.0"
+(defproject com.taoensso/sente "1.18.0-SNAPSHOT"
   :author "Peter Taoussanis <https://www.taoensso.com>"
   :description "Realtime web comms for Clojure/Script"
   :url "https://github.com/ptaoussanis/sente"

--- a/project.clj
+++ b/project.clj
@@ -2,13 +2,15 @@
   :author "Peter Taoussanis <https://www.taoensso.com>"
   :description "Realtime web comms for Clojure/Script"
   :url "https://github.com/ptaoussanis/sente"
-  :license {:name "Eclipse Public License"
-            :url  "http://www.eclipse.org/legal/epl-v10.html"
-            :distribution :repo
-            :comments "Same as Clojure"}
   :min-lein-version "2.3.3"
-  :global-vars {*warn-on-reflection* true
-                *assert* true}
+
+  :license
+  {:name "Eclipse Public License 1.0"
+   :url  "http://www.eclipse.org/legal/epl-v10.html"}
+
+  :global-vars
+  {*warn-on-reflection* true
+   *assert* true}
 
   :dependencies
   [[org.clojure/core.async   "1.6.673"]

--- a/project.clj
+++ b/project.clj
@@ -11,11 +11,11 @@
                 *assert* true}
 
   :dependencies
-  [[org.clojure/core.async   "1.5.648"]
-   [com.taoensso/encore      "3.23.0"]
+  [[org.clojure/core.async   "1.6.673"]
+   [com.taoensso/encore      "3.50.0"]
    [org.java-websocket/Java-WebSocket "1.5.3"]
    [org.clojure/tools.reader "1.3.6"]
-   [com.taoensso/timbre      "5.2.1"]]
+   [com.taoensso/timbre      "6.1.0"]]
 
   :plugins
   [[lein-pprint    "1.3.2"]
@@ -27,7 +27,7 @@
   {;; :default [:base :system :user :provided :dev]
    :server-jvm {:jvm-opts ^:replace ["-server"]}
    :provided {:dependencies [[org.clojure/clojure       "1.10.2"]
-                             [org.clojure/clojurescript "1.11.57"]]}
+                             [org.clojure/clojurescript "1.11.60"]]}
    :1.8      {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9      {:dependencies [[org.clojure/clojure "1.9.0"]]}
    :1.10     {:dependencies [[org.clojure/clojure "1.10.2"]]}
@@ -36,15 +36,15 @@
    :dev      [:1.11 :test :server-jvm :depr]
    :test     {:dependencies
               [[com.cognitect/transit-clj  "1.0.329"]
-               [com.cognitect/transit-cljs "0.8.269"]
+               [com.cognitect/transit-cljs "0.8.280"]
                [org.clojure/test.check     "1.1.1"]
                [http-kit         "2.6.0"]
                [org.immutant/web "2.1.10"]
                [nginx-clojure    "0.5.3"]
-               [aleph            "0.4.7"]
+               [aleph            "0.6.1"]
                [macchiato/core   "0.2.22"]
-               [luminus/ring-undertow-adapter  "1.2.5"]
-               [info.sunng/ring-jetty9-adapter "0.17.6"]]}}
+               [luminus/ring-undertow-adapter  "1.3.0"]
+               [info.sunng/ring-jetty9-adapter "0.18.5"]]}}
 
   :cljsbuild
   {:test-commands {"node"    ["node" :node-runner "target/main.js"]

--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -214,7 +214,7 @@
       (enc/str-starts-with? packed "+") [(subs packed 1) :v1/wrapped]
       (enc/str-starts-with? packed "-") [(subs packed 1) :v1/unwrapped]
       :else                             [      packed    :v2/unwrapped])
-    packed))
+    [packed :v2/unwrapped]))
 
 (comment (parse-packed "+[[\"foo\"] \"uuid\"]"))
 

--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -91,9 +91,7 @@
   #?(:clj  (:import [org.java_websocket.client WebSocketClient])))
 
 (enc/assert-min-encore-version [3 49 0])
-
-(def sente-version "Useful for identifying client/server mismatch"
-  [1 11 0])
+(def sente-version "Useful for identifying client/server mismatch" [1 18 0])
 
 #?(:cljs (def ^:private node-target? (= *target* "nodejs")))
 

--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -90,9 +90,7 @@
   #?(:cljs (:require-macros [taoensso.sente :as sente-macros :refer [elide-require]]))
   #?(:clj  (:import [org.java_websocket.client WebSocketClient])))
 
-(if (vector? taoensso.encore/encore-version)
-  (enc/assert-min-encore-version [2 105 0])
-  (enc/assert-min-encore-version  2.105))
+(enc/assert-min-encore-version [3 49 0])
 
 (def sente-version "Useful for identifying client/server mismatch"
   [1 11 0])

--- a/src/taoensso/sente/server_adapters/community/aleph.clj
+++ b/src/taoensso/sente/server_adapters/community/aleph.clj
@@ -1,4 +1,4 @@
-(ns taoensso.sente.server-adapters.aleph
+(ns taoensso.sente.server-adapters.community.aleph
   "Sente server adapter for Aleph (https://github.com/ztellman/aleph)."
   {:author "Soren Macbeth (@sorenmacbeth)"}
   (:require

--- a/src/taoensso/sente/server_adapters/community/dogfort.cljs
+++ b/src/taoensso/sente/server_adapters/community/dogfort.cljs
@@ -1,4 +1,4 @@
-(ns taoensso.sente.server-adapters.dogfort
+(ns taoensso.sente.server-adapters.community.dogfort
   "Sente server adapter for Node.js with Dog Fort
   (https://github.com/whamtet/dogfort)."
   {:author "Matthew Molloy <@whamtet>"}

--- a/src/taoensso/sente/server_adapters/community/express.cljs
+++ b/src/taoensso/sente/server_adapters/community/express.cljs
@@ -1,4 +1,4 @@
-(ns taoensso.sente.server-adapters.express
+(ns taoensso.sente.server-adapters.community.express
   "Sente server adapter for Node.js with Express (http://expressjs.com/).
 
   This adapter works differently that the others as Sente is

--- a/src/taoensso/sente/server_adapters/community/generic_node.cljs
+++ b/src/taoensso/sente/server_adapters/community/generic_node.cljs
@@ -1,4 +1,4 @@
-(ns taoensso.sente.server-adapters.generic-node
+(ns taoensso.sente.server-adapters.community.generic-node
   "Sente server adapter for Node.js using the `ws` and `http` libraries.
   Ref. https://github.com/websockets/ws,
        https://nodejs.org/api/http.html,

--- a/src/taoensso/sente/server_adapters/community/immutant.clj
+++ b/src/taoensso/sente/server_adapters/community/immutant.clj
@@ -1,4 +1,4 @@
-(ns taoensso.sente.server-adapters.immutant
+(ns taoensso.sente.server-adapters.community.immutant
   "Sente server adapter for Immutant v2+ (http://immutant.org/)."
   {:author "Toby Crawley (@tobias)"}
   (:require

--- a/src/taoensso/sente/server_adapters/community/macchiato.cljs
+++ b/src/taoensso/sente/server_adapters/community/macchiato.cljs
@@ -1,4 +1,4 @@
-(ns taoensso.sente.server-adapters.macchiato
+(ns taoensso.sente.server-adapters.community.macchiato
   "Sente server adapter for Node.js with the Macchiato Framework
   (https://macchiato-framework.github.io/)."
   {:author "Andrew Phillips <@theasp>"}

--- a/src/taoensso/sente/server_adapters/community/nginx_clojure.clj
+++ b/src/taoensso/sente/server_adapters/community/nginx_clojure.clj
@@ -1,4 +1,4 @@
-(ns taoensso.sente.server-adapters.nginx-clojure
+(ns taoensso.sente.server-adapters.community.nginx-clojure
   "Sente server adapter for Nginx-Clojure v0.4.2+
   (http://nginx-clojure.github.io/)."
   {:author "Zhang Yuexiang (@xfeep)"}

--- a/src/taoensso/sente/server_adapters/community/undertow.clj
+++ b/src/taoensso/sente/server_adapters/community/undertow.clj
@@ -1,4 +1,4 @@
-(ns taoensso.sente.server-adapters.undertow
+(ns taoensso.sente.server-adapters.community.undertow
   "Sente server adapter for ring-undertow-adapter."
   {:author "Nik Peric"}
   (:require


### PR DESCRIPTION
Hey,
  Thanks for getting the binary support updates I made merged into mainline sente!  I've finally gotten back around to moving our platform over to your latest release, and I found one minor bug that pops up when using arraybuffers (msgpack) for the binary packed format.  The sente/parse-packed function is expected to always return a tuple of packed + format, but in the non string case it is only returning the packed value.  With this commit everything works as expected, although I'm not 100% familiar with the v1/v2 wrapp/unwrap scheme you are using for this transition so this might not be quite write.  I'm thinking maybe the (string? packed) should be the first clause in the cond, and then it should return [packed :v2/unwrapped], but maybe there are string versions that also need to do that?