### PR TITLE
Add UUID support to msgpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project uses [**Break Versioning**](https://www.taoensso.com/break-versioni
 
 Like `v1.21.0-RC1` but adds some performance improvements and fixes to Sente's new experimental [binary serialization](https://cljdoc.org/d/com.taoensso/sente/CURRENT/api/taoensso.sente.packers.msgpack).
 
+---
+
 # `v1.21.0-RC1` (2025-09-02)
 
 - **Dependency**: [on Clojars](https://clojars.org/com.taoensso/sente/versions/1.21.0-RC1)

--- a/src/taoensso/msgpack/impl.clj
+++ b/src/taoensso/msgpack/impl.clj
@@ -321,6 +321,10 @@
   (unpack [ba]
     (CachedKey. (get @c/*key-cache_* (bit-and 0xff (aget ^bytes ba 0))))))
 
+(c/extend-packable 9 java.util.UUID
+  (pack   [u]  (.getBytes (str u)                            StandardCharsets/UTF_8))
+  (unpack [ba] (java.util.UUID/fromString (String. ^bytes ba StandardCharsets/UTF_8))))
+
 ;;;;
 
 (defn pack

--- a/src/taoensso/msgpack/impl.cljs
+++ b/src/taoensso/msgpack/impl.cljs
@@ -452,6 +452,10 @@
   (unpack [u8s]
     (CachedKey. (get @c/*key-cache_* (aget ^js u8s 0)))))
 
+(c/extend-packable 9 UUID
+  (pack   [u]       (.encode text-encoder (str u)))
+  (unpack [^js u8s] (uuid (.decode text-decoder ^js u8s))))
+
 ;;;;
 
 (defn unpack [in] (unpack-1 (in-stream* in)))

--- a/test/taoensso/msgpack_tests.cljc
+++ b/test/taoensso/msgpack_tests.cljc
@@ -118,6 +118,8 @@
    #?(:clj  (is (rt? "Timestamps" (java.time.Instant/now) (java.util.Date.) (java.util.Date. -1))))
    #?(:cljs (is (rt? "Timestamps" (js/Date.))))
 
+   (rt? "UUID" #uuid "66d96ab4-9834-40db-a3cd-42b361503ab9")
+
    (testing "Key caching"
      [(rt? "Basic" [{:a :A} {:a :A}] {:foo {1 {:x :X} 2 {:y :Y}}})
       (rt? ">256    keys" (let [m (into {} (map (fn [n] [(str "key" n) n])) (range 512))] [m m {:a :A :b :B} m]))


### PR DESCRIPTION
If we try to pack a UUID, we will receive an error (StackOverflowError in Clojure). The idea is to add the necessary extension to support UUID when using msgpack as the Packer.